### PR TITLE
feat: P3 Batch 2 - 5星武器 Stacks ConditionalBuff追加（9本）

### DIFF
--- a/crates/data/src/weapons/bow.rs
+++ b/crates/data/src/weapons/bow.rs
@@ -3,6 +3,7 @@ use crate::buff::{
     PassiveEffect, StatBuff,
 };
 use crate::types::{Rarity, WeaponData, WeaponPassive, WeaponSubStat, WeaponType};
+use genshin_calc_core::Element;
 
 // =============================================================================
 // 5-Star Bows
@@ -76,9 +77,30 @@ pub const ASTRAL_VULTURES_CRIMSON_PLUMAGE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Astral Vulture's Crimson Plumage",
         effect: PassiveEffect {
-            description: "Conditional: 夜魂のスタック蓄積でATKとDMGアップ",
+            description: "夜魂スタック蓄積でATK+12-24%（最大3スタック）、フルスタックでDMG+12-24%",
             buffs: &[],
-            conditional_buffs: &[],
+            conditional_buffs: &[
+                ConditionalBuff {
+                    name: "astral_vulture_atk_stacks",
+                    description: "夜魂スタックでATK+12-24%（1スタック）、最大3スタック",
+                    stat: BuffableStat::AtkPercent,
+                    value: 0.12,
+                    refinement_values: Some([0.12, 0.15, 0.18, 0.21, 0.24]),
+                    stack_values: None,
+                    target: BuffTarget::OnlySelf,
+                    activation: Activation::Manual(ManualCondition::Stacks(3)),
+                },
+                ConditionalBuff {
+                    name: "astral_vulture_full_stack_dmg",
+                    description: "フルスタック時にDMG+12-24%",
+                    stat: BuffableStat::DmgBonus,
+                    value: 0.12,
+                    refinement_values: Some([0.12, 0.15, 0.18, 0.21, 0.24]),
+                    stack_values: None,
+                    target: BuffTarget::OnlySelf,
+                    activation: Activation::Manual(ManualCondition::Toggle),
+                },
+            ],
         },
     }),
 };
@@ -172,9 +194,30 @@ pub const SILVERSHOWER_HEARTSTRINGS: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Silvershower Heartstrings",
         effect: PassiveEffect {
-            description: "Conditional: 元素スキル使用でHP上限アップ。3スタックでHydro DMGアップ",
+            description: "元素スキル使用でHP+12-24%スタック（最大3）、3スタックでHydro DMG+28-56%",
             buffs: &[],
-            conditional_buffs: &[],
+            conditional_buffs: &[
+                ConditionalBuff {
+                    name: "silvershower_hp_stacks",
+                    description: "元素スキル使用でHP+12-24%（1スタック）、最大3スタック",
+                    stat: BuffableStat::HpPercent,
+                    value: 0.12,
+                    refinement_values: Some([0.12, 0.15, 0.18, 0.21, 0.24]),
+                    stack_values: None,
+                    target: BuffTarget::OnlySelf,
+                    activation: Activation::Manual(ManualCondition::Stacks(3)),
+                },
+                ConditionalBuff {
+                    name: "silvershower_full_stack_hydro_dmg",
+                    description: "3スタック時にHydro DMG+28-56%",
+                    stat: BuffableStat::ElementalDmgBonus(Element::Hydro),
+                    value: 0.28,
+                    refinement_values: Some([0.28, 0.35, 0.42, 0.49, 0.56]),
+                    stack_values: None,
+                    target: BuffTarget::OnlySelf,
+                    activation: Activation::Manual(ManualCondition::Toggle),
+                },
+            ],
         },
     }),
 };
@@ -210,9 +253,18 @@ pub const THE_DAYBREAK_CHRONICLES: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "The Daybreak Chronicles",
         effect: PassiveEffect {
-            description: "Conditional: 物語のスタック蓄積でDMGアップ",
+            description: "物語のスタック蓄積でDMG+8-16%（最大3スタック）",
             buffs: &[],
-            conditional_buffs: &[],
+            conditional_buffs: &[ConditionalBuff {
+                name: "the_daybreak_chronicles_dmg_stacks",
+                description: "物語のスタックでDMG+8-16%（1スタック）、最大3スタック",
+                stat: BuffableStat::DmgBonus,
+                value: 0.08,
+                refinement_values: Some([0.08, 0.10, 0.12, 0.14, 0.16]),
+                stack_values: None,
+                target: BuffTarget::OnlySelf,
+                activation: Activation::Manual(ManualCondition::Stacks(3)),
+            }],
         },
     }),
 };
@@ -947,5 +999,74 @@ mod tests {
                 cap: None,
             })
         ));
+    }
+
+    #[test]
+    fn astral_vulture_has_atk_stacks_and_full_stack_dmg() {
+        let passive = ASTRAL_VULTURES_CRIMSON_PLUMAGE.passive.unwrap();
+        let cond_buffs = passive.effect.conditional_buffs;
+        assert_eq!(cond_buffs.len(), 2);
+
+        let stacks_buff = &cond_buffs[0];
+        assert_eq!(stacks_buff.name, "astral_vulture_atk_stacks");
+        assert_eq!(stacks_buff.stat, BuffableStat::AtkPercent);
+        assert!((stacks_buff.value - 0.12).abs() < 1e-6);
+        assert!(matches!(
+            stacks_buff.activation,
+            Activation::Manual(ManualCondition::Stacks(3))
+        ));
+
+        let full_buff = &cond_buffs[1];
+        assert_eq!(full_buff.name, "astral_vulture_full_stack_dmg");
+        assert_eq!(full_buff.stat, BuffableStat::DmgBonus);
+        assert!((full_buff.value - 0.12).abs() < 1e-6);
+        assert!(matches!(
+            full_buff.activation,
+            Activation::Manual(ManualCondition::Toggle)
+        ));
+    }
+
+    #[test]
+    fn silvershower_has_hp_stacks_and_hydro_dmg() {
+        let passive = SILVERSHOWER_HEARTSTRINGS.passive.unwrap();
+        let cond_buffs = passive.effect.conditional_buffs;
+        assert_eq!(cond_buffs.len(), 2);
+
+        let stacks_buff = &cond_buffs[0];
+        assert_eq!(stacks_buff.name, "silvershower_hp_stacks");
+        assert_eq!(stacks_buff.stat, BuffableStat::HpPercent);
+        assert!((stacks_buff.value - 0.12).abs() < 1e-6);
+        assert!(matches!(
+            stacks_buff.activation,
+            Activation::Manual(ManualCondition::Stacks(3))
+        ));
+
+        let full_buff = &cond_buffs[1];
+        assert_eq!(full_buff.name, "silvershower_full_stack_hydro_dmg");
+        assert_eq!(
+            full_buff.stat,
+            BuffableStat::ElementalDmgBonus(genshin_calc_core::Element::Hydro)
+        );
+        assert!((full_buff.value - 0.28).abs() < 1e-6);
+        assert!(matches!(
+            full_buff.activation,
+            Activation::Manual(ManualCondition::Toggle)
+        ));
+    }
+
+    #[test]
+    fn daybreak_chronicles_has_dmg_stacks() {
+        let passive = THE_DAYBREAK_CHRONICLES.passive.unwrap();
+        let cond_buffs = passive.effect.conditional_buffs;
+        assert_eq!(cond_buffs.len(), 1);
+        let buff = &cond_buffs[0];
+        assert_eq!(buff.name, "the_daybreak_chronicles_dmg_stacks");
+        assert_eq!(buff.stat, BuffableStat::DmgBonus);
+        assert!((buff.value - 0.08).abs() < 1e-6);
+        assert!(matches!(
+            buff.activation,
+            Activation::Manual(ManualCondition::Stacks(3))
+        ));
+        assert!(buff.refinement_values.is_some());
     }
 }

--- a/crates/data/src/weapons/catalyst.rs
+++ b/crates/data/src/weapons/catalyst.rs
@@ -121,9 +121,30 @@ pub const KAGURAS_VERITY: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Kagura's Verity",
         effect: PassiveEffect {
-            description: "Conditional: 元素スキル使用でスキルDMGスタック、3スタックで元素DMGアップ",
+            description: "元素スキル使用でスキルDMG+12-24%スタック（最大3）、3スタックで元素DMG+12-24%",
             buffs: &[],
-            conditional_buffs: &[],
+            conditional_buffs: &[
+                ConditionalBuff {
+                    name: "kagura_skill_dmg_stacks",
+                    description: "元素スキル使用でスキルDMG+12-24%（1スタック）、最大3スタック",
+                    stat: BuffableStat::SkillDmgBonus,
+                    value: 0.12,
+                    refinement_values: Some([0.12, 0.15, 0.18, 0.21, 0.24]),
+                    stack_values: None,
+                    target: BuffTarget::OnlySelf,
+                    activation: Activation::Manual(ManualCondition::Stacks(3)),
+                },
+                ConditionalBuff {
+                    name: "kagura_full_stack_elemental_dmg",
+                    description: "3スタック時に元素DMG+12-24%（DmgBonus近似値、物理除外）",
+                    stat: BuffableStat::DmgBonus,
+                    value: 0.12,
+                    refinement_values: Some([0.12, 0.15, 0.18, 0.21, 0.24]),
+                    stack_values: None,
+                    target: BuffTarget::OnlySelf,
+                    activation: Activation::Manual(ManualCondition::Toggle),
+                },
+            ],
         },
     }),
 };
@@ -198,9 +219,18 @@ pub const NOCTURNES_CURTAIN_CALL: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Nocturne's Curtain Call",
         effect: PassiveEffect {
-            description: "Conditional: 元素スキル/爆発命中でスタック獲得、DMGアップ",
+            description: "元素スキル/爆発命中でDMG+8-16%スタック（最大5スタック）",
             buffs: &[],
-            conditional_buffs: &[],
+            conditional_buffs: &[ConditionalBuff {
+                name: "nocturne_dmg_stacks",
+                description: "元素スキル/爆発命中でDMG+8-16%（1スタック）、最大5スタック",
+                stat: BuffableStat::DmgBonus,
+                value: 0.08,
+                refinement_values: Some([0.08, 0.10, 0.12, 0.14, 0.16]),
+                stack_values: None,
+                target: BuffTarget::OnlySelf,
+                activation: Activation::Manual(ManualCondition::Stacks(5)),
+            }],
         },
     }),
 };
@@ -329,9 +359,18 @@ pub const TULAYTULLAHS_REMEMBRANCE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Tulaytullah's Remembrance",
         effect: PassiveEffect {
-            description: "Conditional: 通常攻撃速度アップ、NA DMGスタック",
+            description: "通常攻撃DMG+4.8-9.6%スタック（最大10スタック、1秒毎）。攻撃速度バフは非対応",
             buffs: &[],
-            conditional_buffs: &[],
+            conditional_buffs: &[ConditionalBuff {
+                name: "tulaytullah_na_dmg_stacks",
+                description: "通常攻撃DMG+4.8-9.6%（1スタック）、最大10スタック",
+                stat: BuffableStat::NormalAtkDmgBonus,
+                value: 0.048,
+                refinement_values: Some([0.048, 0.06, 0.072, 0.084, 0.096]),
+                stack_values: None,
+                target: BuffTarget::OnlySelf,
+                activation: Activation::Manual(ManualCondition::Stacks(10)),
+            }],
         },
     }),
 };
@@ -346,9 +385,18 @@ pub const VIVID_NOTIONS: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Vivid Notions",
         effect: PassiveEffect {
-            description: "Conditional: 夜魂バースト時にDMGアップスタック",
+            description: "夜魂バースト時にDMG+8-16%スタック（最大3スタック）",
             buffs: &[],
-            conditional_buffs: &[],
+            conditional_buffs: &[ConditionalBuff {
+                name: "vivid_notions_dmg_stacks",
+                description: "夜魂バースト時にDMG+8-16%（1スタック）、最大3スタック",
+                stat: BuffableStat::DmgBonus,
+                value: 0.08,
+                refinement_values: Some([0.08, 0.10, 0.12, 0.14, 0.16]),
+                stack_values: None,
+                target: BuffTarget::OnlySelf,
+                activation: Activation::Manual(ManualCondition::Stacks(3)),
+            }],
         },
     }),
 };
@@ -972,3 +1020,81 @@ pub const ALL_CATALYSTS: &[&WeaponData] = &[
     &APPRENTICES_NOTES,
     &POCKET_GRIMOIRE,
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kagura_has_skill_dmg_stacks_and_full_stack_bonus() {
+        let passive = KAGURAS_VERITY.passive.unwrap();
+        let cond_buffs = passive.effect.conditional_buffs;
+        assert_eq!(cond_buffs.len(), 2);
+
+        let stacks_buff = &cond_buffs[0];
+        assert_eq!(stacks_buff.name, "kagura_skill_dmg_stacks");
+        assert_eq!(stacks_buff.stat, BuffableStat::SkillDmgBonus);
+        assert!((stacks_buff.value - 0.12).abs() < 1e-6);
+        assert!(matches!(
+            stacks_buff.activation,
+            Activation::Manual(ManualCondition::Stacks(3))
+        ));
+
+        let full_buff = &cond_buffs[1];
+        assert_eq!(full_buff.name, "kagura_full_stack_elemental_dmg");
+        assert_eq!(full_buff.stat, BuffableStat::DmgBonus);
+        assert!((full_buff.value - 0.12).abs() < 1e-6);
+        assert!(matches!(
+            full_buff.activation,
+            Activation::Manual(ManualCondition::Toggle)
+        ));
+    }
+
+    #[test]
+    fn tulaytullah_has_na_dmg_stacks() {
+        let passive = TULAYTULLAHS_REMEMBRANCE.passive.unwrap();
+        let cond_buffs = passive.effect.conditional_buffs;
+        assert_eq!(cond_buffs.len(), 1);
+        let buff = &cond_buffs[0];
+        assert_eq!(buff.name, "tulaytullah_na_dmg_stacks");
+        assert_eq!(buff.stat, BuffableStat::NormalAtkDmgBonus);
+        assert!((buff.value - 0.048).abs() < 1e-6);
+        assert!(matches!(
+            buff.activation,
+            Activation::Manual(ManualCondition::Stacks(10))
+        ));
+        assert!(buff.refinement_values.is_some());
+    }
+
+    #[test]
+    fn nocturne_has_dmg_stacks() {
+        let passive = NOCTURNES_CURTAIN_CALL.passive.unwrap();
+        let cond_buffs = passive.effect.conditional_buffs;
+        assert_eq!(cond_buffs.len(), 1);
+        let buff = &cond_buffs[0];
+        assert_eq!(buff.name, "nocturne_dmg_stacks");
+        assert_eq!(buff.stat, BuffableStat::DmgBonus);
+        assert!((buff.value - 0.08).abs() < 1e-6);
+        assert!(matches!(
+            buff.activation,
+            Activation::Manual(ManualCondition::Stacks(5))
+        ));
+        assert!(buff.refinement_values.is_some());
+    }
+
+    #[test]
+    fn vivid_notions_has_dmg_stacks() {
+        let passive = VIVID_NOTIONS.passive.unwrap();
+        let cond_buffs = passive.effect.conditional_buffs;
+        assert_eq!(cond_buffs.len(), 1);
+        let buff = &cond_buffs[0];
+        assert_eq!(buff.name, "vivid_notions_dmg_stacks");
+        assert_eq!(buff.stat, BuffableStat::DmgBonus);
+        assert!((buff.value - 0.08).abs() < 1e-6);
+        assert!(matches!(
+            buff.activation,
+            Activation::Manual(ManualCondition::Stacks(3))
+        ));
+        assert!(buff.refinement_values.is_some());
+    }
+}

--- a/crates/data/src/weapons/claymore.rs
+++ b/crates/data/src/weapons/claymore.rs
@@ -63,9 +63,18 @@ pub const FANG_OF_THE_MOUNTAIN_KING: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Fang of the Mountain King",
         effect: PassiveEffect {
-            description: "Conditional: 元素スキル命中でスタック獲得、スタック数に応じて元素ダメージアップ",
+            description: "元素スキル命中でDMG+10-20%スタック（最大3スタック）。DmgBonus近似値（実際は全元素DMG、物理除外）",
             buffs: &[],
-            conditional_buffs: &[],
+            conditional_buffs: &[ConditionalBuff {
+                name: "fang_mountain_king_elemental_dmg_stacks",
+                description: "元素スキル命中でDMG+10-20%（1スタック）、最大3スタック（DmgBonus近似値、物理除外）",
+                stat: BuffableStat::DmgBonus,
+                value: 0.10,
+                refinement_values: Some([0.10, 0.125, 0.15, 0.175, 0.20]),
+                stack_values: None,
+                target: BuffTarget::OnlySelf,
+                activation: Activation::Manual(ManualCondition::Stacks(3)),
+            }],
         },
     }),
 };
@@ -909,5 +918,21 @@ mod tests {
                 })
             ));
         }
+    }
+
+    #[test]
+    fn fang_of_mountain_king_has_dmg_stacks() {
+        let passive = FANG_OF_THE_MOUNTAIN_KING.passive.unwrap();
+        let cond_buffs = passive.effect.conditional_buffs;
+        assert_eq!(cond_buffs.len(), 1);
+        let buff = &cond_buffs[0];
+        assert_eq!(buff.name, "fang_mountain_king_elemental_dmg_stacks");
+        assert_eq!(buff.stat, BuffableStat::DmgBonus);
+        assert!((buff.value - 0.10).abs() < 1e-6);
+        assert!(matches!(
+            buff.activation,
+            Activation::Manual(ManualCondition::Stacks(3))
+        ));
+        assert!(buff.refinement_values.is_some());
     }
 }

--- a/crates/data/src/weapons/polearm.rs
+++ b/crates/data/src/weapons/polearm.rs
@@ -141,9 +141,30 @@ pub const PRIMORDIAL_JADE_WINGED_SPEAR: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "昭理の鳶",
         effect: PassiveEffect {
-            description: "Conditional: 命中時にATK+3.2-6%、6スタックまで。フルスタックでDMG+12-24%",
+            description: "命中時にATK+3.2-6%、6スタックまで。フルスタックでDMG+12-24%",
             buffs: &[],
-            conditional_buffs: &[],
+            conditional_buffs: &[
+                ConditionalBuff {
+                    name: "pjws_atk_stacks",
+                    description: "命中時にATK+3.2-6%（1スタック）、最大6スタック",
+                    stat: BuffableStat::AtkPercent,
+                    value: 0.032,
+                    refinement_values: Some([0.032, 0.039, 0.046, 0.053, 0.060]),
+                    stack_values: None,
+                    target: BuffTarget::OnlySelf,
+                    activation: Activation::Manual(ManualCondition::Stacks(6)),
+                },
+                ConditionalBuff {
+                    name: "pjws_full_stack_dmg",
+                    description: "フルスタック時にDMG+12-24%",
+                    stat: BuffableStat::DmgBonus,
+                    value: 0.12,
+                    refinement_values: Some([0.12, 0.15, 0.18, 0.21, 0.24]),
+                    stack_values: None,
+                    target: BuffTarget::OnlySelf,
+                    activation: Activation::Manual(ManualCondition::Toggle),
+                },
+            ],
         },
     }),
 };
@@ -893,6 +914,32 @@ mod tests {
                 offset: None,
                 cap: None,
             })
+        ));
+    }
+
+    #[test]
+    fn pjws_has_atk_stacks_and_full_stack_dmg() {
+        let passive = PRIMORDIAL_JADE_WINGED_SPEAR.passive.unwrap();
+        let cond_buffs = passive.effect.conditional_buffs;
+        assert_eq!(cond_buffs.len(), 2);
+
+        let stacks_buff = &cond_buffs[0];
+        assert_eq!(stacks_buff.name, "pjws_atk_stacks");
+        assert_eq!(stacks_buff.stat, BuffableStat::AtkPercent);
+        assert!((stacks_buff.value - 0.032).abs() < 1e-6);
+        assert!(matches!(
+            stacks_buff.activation,
+            Activation::Manual(ManualCondition::Stacks(6))
+        ));
+        assert!(stacks_buff.refinement_values.is_some());
+
+        let full_buff = &cond_buffs[1];
+        assert_eq!(full_buff.name, "pjws_full_stack_dmg");
+        assert_eq!(full_buff.stat, BuffableStat::DmgBonus);
+        assert!((full_buff.value - 0.12).abs() < 1e-6);
+        assert!(matches!(
+            full_buff.activation,
+            Activation::Manual(ManualCondition::Toggle)
         ));
     }
 }


### PR DESCRIPTION
Closes #15

9本の5星武器にManualCondition::Stacks ConditionalBuffを追加。
coreクレートへΟ変更なし（data crateのみ）。
9ユニットテスト追加、全テストpass確認済。

Generated with [Claude Code](https://claude.ai/code)