### PR TITLE
feat: add BuffableStat::ElementalRes and implement 2pc for Thundersoother/Lavawalker/Tiny Miracle

### DIFF
--- a/crates/core/src/buff_types.rs
+++ b/crates/core/src/buff_types.rs
@@ -28,6 +28,8 @@ pub enum BuffableStat {
     AmplifyingBonus,
     TransformativeBonus,
     AdditiveBonus,
+    // Player-side elemental resistance (stored, not applied to damage calculation pipeline)
+    ElementalRes(Element),
     // Enemy resistance reduction (consumed by damage calculation, not applied to StatProfile)
     ElementalResReduction(Element),
     PhysicalResReduction,
@@ -45,6 +47,25 @@ pub enum BuffableStat {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_elemental_res_serde_roundtrip() {
+        use crate::types::Element;
+        for element in [
+            Element::Pyro,
+            Element::Hydro,
+            Element::Electro,
+            Element::Cryo,
+            Element::Dendro,
+            Element::Anemo,
+            Element::Geo,
+        ] {
+            let stat = BuffableStat::ElementalRes(element);
+            let json = serde_json::to_string(&stat).unwrap();
+            let deser: BuffableStat = serde_json::from_str(&json).unwrap();
+            assert_eq!(stat, deser);
+        }
+    }
 
     #[test]
     fn test_def_reduction_serde_roundtrip() {

--- a/crates/data/src/artifacts.rs
+++ b/crates/data/src/artifacts.rs
@@ -229,7 +229,11 @@ pub const THUNDERSOOTHER: ArtifactSet = ArtifactSet {
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
         description: "雷元素耐性+40%",
-        buffs: &[],
+        buffs: &[StatBuff {
+            stat: BuffableStat::ElementalRes(Element::Electro),
+            value: 0.40,
+            refinement_values: None,
+        }],
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
@@ -406,7 +410,11 @@ pub const LAVAWALKER: ArtifactSet = ArtifactSet {
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
         description: "炎元素耐性+40%",
-        buffs: &[],
+        buffs: &[StatBuff {
+            stat: BuffableStat::ElementalRes(Element::Pyro),
+            value: 0.40,
+            refinement_values: None,
+        }],
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
@@ -1462,7 +1470,43 @@ pub const TINY_MIRACLE: ArtifactSet = ArtifactSet {
     rarity: ArtifactRarity::Star4And5,
     two_piece: SetEffect {
         description: "全元素耐性+20%",
-        buffs: &[],
+        buffs: &[
+            StatBuff {
+                stat: BuffableStat::ElementalRes(Element::Pyro),
+                value: 0.20,
+                refinement_values: None,
+            },
+            StatBuff {
+                stat: BuffableStat::ElementalRes(Element::Hydro),
+                value: 0.20,
+                refinement_values: None,
+            },
+            StatBuff {
+                stat: BuffableStat::ElementalRes(Element::Electro),
+                value: 0.20,
+                refinement_values: None,
+            },
+            StatBuff {
+                stat: BuffableStat::ElementalRes(Element::Cryo),
+                value: 0.20,
+                refinement_values: None,
+            },
+            StatBuff {
+                stat: BuffableStat::ElementalRes(Element::Dendro),
+                value: 0.20,
+                refinement_values: None,
+            },
+            StatBuff {
+                stat: BuffableStat::ElementalRes(Element::Anemo),
+                value: 0.20,
+                refinement_values: None,
+            },
+            StatBuff {
+                stat: BuffableStat::ElementalRes(Element::Geo),
+                value: 0.20,
+                refinement_values: None,
+            },
+        ],
         conditional_buffs: &[],
     },
     four_piece: SetEffect {

--- a/docs/data-expansion-todo.md
+++ b/docs/data-expansion-todo.md
@@ -8,7 +8,7 @@ genshin-calc-data crateのデータカバレッジ拡充ロードマップ。
 |----------|-----:|--------:|-------:|-----------:|
 | 武器パッシブ (StatBuff) | 220 | 220 | 0 | 100% |
 | 武器パッシブ (ConditionalBuff) | 220 | 77 | 143 | 35% |
-| 聖遺物2pc (StatBuff) | 52 | 45 | 7 | 87% |
+| 聖遺物2pc (StatBuff) | 52 | 48 | 4 | 92% |
 | 聖遺物4pc効果 | 52 | 52 | 0 | 100% |
 | 天賦バフ/デバフ (TalentBuffDef) | 29キャラ | 47定義 | 1(Nilou) | ~97% |
 | 敵データ | 多数 | 40 | 多数 | - |
@@ -84,11 +84,14 @@ P2/P3/P4/P6のアンロックキー。
 
 ## P2: 聖遺物セット効果の充実 ✅
 
-4pc効果は全52セット実装完了。2pcは45/52実装済み。
+4pc効果は全52セット実装完了。2pcは48/52実装済み。
 
 ### 2pc効果 (単純バフ)
 
 - [ ] 未実装の2pc効果を洗い出して埋める (大半は無条件バフ、既に高カバレッジ)
+- [x] 雷を鎮める尊者 (Thundersoother) — 雷元素耐性+40% (ElementalRes(Electro))
+- [x] 烈火を渡る賢者 (Lavawalker) — 炎元素耐性+40% (ElementalRes(Pyro))
+- [x] 奇跡 (Tiny Miracle) — 全元素耐性+20% (ElementalRes × 7元素)
 
 ### 4pc効果 (条件付き — P0依存)
 
@@ -228,4 +231,4 @@ core crateに `apply_enemy_debuffs(enemy, buffs, element) -> Enemy` 関数を実
 ### 残タスク
 
 - **P1 Nilou** — 開花反応ボーナス (水草限定条件、特殊実装が必要)
-- **P2 2pc効果** — 残り7セットのStatBuff
+- **P2 2pc効果** — 残り4セットのStatBuff


### PR DESCRIPTION
Closes #24

## Changes

- Add `BuffableStat::ElementalRes(Element)` variant for player-side elemental resistance
- Implement Thundersoother 2pc: Electro RES +40%
- Implement Lavawalker 2pc: Pyro RES +40%
- Implement Tiny Miracle 2pc: all 7 elemental RES +20%
- Add serde roundtrip test for the new variant
- Update data-expansion-todo.md: 2pc coverage 45→48/52 (87%→92%)

Generated with [Claude Code](https://claude.ai/code)