### PR TITLE
fix: correct Xilonen/Mavuika/Citlali buff definitions (issue #32)

### DIFF
--- a/crates/data/src/talent_buffs/cryo.rs
+++ b/crates/data/src/talent_buffs/cryo.rs
@@ -183,7 +183,7 @@ static SHENHE_BUFFS: &[TalentBuffDef] = &[
 
 // ===== Citlali =====
 // Skill: Pyro/Hydro RES -20%
-// A4: EM = min(Citlali's EM × 0.20, 120)
+// C2 "Heart Devourer's Travail": Party members (excl. Citlali) gain EM+250 while Opal Shield active or Itzpapa following
 // C2: Additional Pyro/Hydro RES -20% (total -40% each)
 static CITLALI_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
@@ -213,17 +213,17 @@ static CITLALI_BUFFS: &[TalentBuffDef] = &[
         cap: None,
     },
     TalentBuffDef {
-        name: "The Sunken Years EM Bonus",
-        description: "A4: Party EM = min(Citlali's EM × 20%, 120)",
+        name: "Heart Devourer's Travail EM Bonus",
+        description: "C2: While Opal Shield is active or Itzpapa is following, nearby party members (excl. Citlali) gain EM+250",
         stat: BuffableStat::ElementalMastery,
-        base_value: 0.20,
+        base_value: 250.0,
         scales_with_talent: false,
         talent_scaling: None,
-        scales_on: Some(ScalingStat::Em),
-        target: BuffTarget::Team,
-        source: TalentBuffSource::AscensionPassive(4),
-        min_constellation: 0,
-        cap: Some(120.0),
+        scales_on: None,
+        target: BuffTarget::TeamExcludeSelf,
+        source: TalentBuffSource::Constellation(2),
+        min_constellation: 2,
+        cap: None,
     },
     TalentBuffDef {
         name: "Cold Moon Pyro RES Shred",

--- a/crates/data/src/talent_buffs/geo.rs
+++ b/crates/data/src/talent_buffs/geo.rs
@@ -280,10 +280,9 @@ static ILLUGA_BUFFS: &[TalentBuffDef] = &[
 
 // ===== Xilonen =====
 // Skill: Elemental RES Reduction per skill level (element depends on party; Geo always active)
-// C4: EM+120 on Nightsoul Point consumption
+// C4 "Suchitl's Trance": Normal/Charged/Plunging ATK deal additional DMG equal to 65% of Xilonen's DEF
 static XILONEN_SKILL_RES_SCALING: [f64; 15] = [
-    0.1296, 0.1394, 0.1491, 0.1620, 0.1718, 0.1814, 0.1944, 0.2074, 0.2203, 0.2333, 0.2462, 0.2592,
-    0.2754, 0.2916, 0.3078,
+    0.09, 0.12, 0.15, 0.18, 0.21, 0.24, 0.27, 0.30, 0.33, 0.36, 0.39, 0.42, 0.45, 0.48, 0.51,
 ];
 
 static XILONEN_BUFFS: &[TalentBuffDef] = &[
@@ -301,13 +300,39 @@ static XILONEN_BUFFS: &[TalentBuffDef] = &[
         cap: None,
     },
     TalentBuffDef {
-        name: "Sunken Flame EM Bonus",
-        description: "C4: Party gains EM+120 when Nightsoul Points are consumed",
-        stat: BuffableStat::ElementalMastery,
-        base_value: 120.0,
+        name: "Suchitl's Trance Normal ATK Flat DMG",
+        description: "C4: Normal, Charged, and Plunging Attacks deal additional DMG equal to 65% of Xilonen's DEF",
+        stat: BuffableStat::NormalAtkFlatDmg,
+        base_value: 0.65,
         scales_with_talent: false,
         talent_scaling: None,
-        scales_on: None,
+        scales_on: Some(ScalingStat::Def),
+        target: BuffTarget::Team,
+        source: TalentBuffSource::Constellation(4),
+        min_constellation: 4,
+        cap: None,
+    },
+    TalentBuffDef {
+        name: "Suchitl's Trance Charged ATK Flat DMG",
+        description: "C4: Normal, Charged, and Plunging Attacks deal additional DMG equal to 65% of Xilonen's DEF",
+        stat: BuffableStat::ChargedAtkFlatDmg,
+        base_value: 0.65,
+        scales_with_talent: false,
+        talent_scaling: None,
+        scales_on: Some(ScalingStat::Def),
+        target: BuffTarget::Team,
+        source: TalentBuffSource::Constellation(4),
+        min_constellation: 4,
+        cap: None,
+    },
+    TalentBuffDef {
+        name: "Suchitl's Trance Plunging ATK Flat DMG",
+        description: "C4: Normal, Charged, and Plunging Attacks deal additional DMG equal to 65% of Xilonen's DEF",
+        stat: BuffableStat::PlungingAtkFlatDmg,
+        base_value: 0.65,
+        scales_with_talent: false,
+        talent_scaling: None,
+        scales_on: Some(ScalingStat::Def),
         target: BuffTarget::Team,
         source: TalentBuffSource::Constellation(4),
         min_constellation: 4,

--- a/crates/data/src/talent_buffs/mod.rs
+++ b/crates/data/src/talent_buffs/mod.rs
@@ -514,15 +514,25 @@ mod tests {
     #[test]
     fn test_find_xilonen_buffs() {
         let buffs = find_talent_buffs("xilonen").unwrap();
-        assert_eq!(buffs.len(), 2);
+        assert_eq!(buffs.len(), 4);
+        // Skill: Geo RES reduction (talent-scaled)
         assert_eq!(
             buffs[0].stat,
             BuffableStat::ElementalResReduction(Element::Geo)
         );
         assert!(buffs[0].scales_with_talent);
-        assert_eq!(buffs[1].stat, BuffableStat::ElementalMastery);
-        assert!((buffs[1].base_value - 120.0).abs() < 1e-6);
+        // C4: flat DMG from DEF for Normal/Charged/Plunging
+        assert_eq!(buffs[1].stat, BuffableStat::NormalAtkFlatDmg);
+        assert!((buffs[1].base_value - 0.65).abs() < 1e-6);
+        assert_eq!(buffs[1].scales_on, Some(ScalingStat::Def));
         assert_eq!(buffs[1].min_constellation, 4);
+        assert_eq!(buffs[2].stat, BuffableStat::ChargedAtkFlatDmg);
+        assert_eq!(buffs[3].stat, BuffableStat::PlungingAtkFlatDmg);
+        for b in &buffs[1..] {
+            assert!((b.base_value - 0.65).abs() < 1e-6);
+            assert_eq!(b.scales_on, Some(ScalingStat::Def));
+            assert_eq!(b.min_constellation, 4);
+        }
     }
 
     #[test]
@@ -539,10 +549,14 @@ mod tests {
             buffs[1].stat,
             BuffableStat::ElementalResReduction(Element::Hydro)
         );
-        // A4: EM from own EM
+        // C2: flat EM+250 for party (excl. Citlali)
         assert_eq!(buffs[2].stat, BuffableStat::ElementalMastery);
-        assert_eq!(buffs[2].scales_on, Some(ScalingStat::Em));
-        assert_eq!(buffs[2].cap, Some(120.0));
+        assert!((buffs[2].base_value - 250.0).abs() < 1e-6);
+        assert_eq!(buffs[2].scales_on, None);
+        assert_eq!(buffs[2].cap, None);
+        assert_eq!(buffs[2].target, BuffTarget::TeamExcludeSelf);
+        assert_eq!(buffs[2].min_constellation, 2);
+        assert_eq!(buffs[2].source, TalentBuffSource::Constellation(2));
         // C2: additional RES shred
         assert_eq!(buffs[3].min_constellation, 2);
         assert_eq!(buffs[4].min_constellation, 2);
@@ -565,12 +579,16 @@ mod tests {
     fn test_find_mavuika_buffs() {
         let buffs = find_talent_buffs("mavuika").unwrap();
         assert_eq!(buffs.len(), 2);
+        // A1: Mavuika's own ATK+30% (self-buff)
         assert_eq!(buffs[0].stat, BuffableStat::AtkPercent);
         assert!((buffs[0].base_value - 0.30).abs() < 1e-6);
         assert_eq!(buffs[0].source, TalentBuffSource::AscensionPassive(1));
-        assert_eq!(buffs[1].stat, BuffableStat::AtkPercent);
-        assert!((buffs[1].base_value - 0.60).abs() < 1e-6);
+        assert_eq!(buffs[0].target, BuffTarget::OnlySelf);
+        // A4: DMG Bonus +40% (max, self-buff)
+        assert_eq!(buffs[1].stat, BuffableStat::DmgBonus);
+        assert!((buffs[1].base_value - 0.40).abs() < 1e-6);
         assert_eq!(buffs[1].source, TalentBuffSource::AscensionPassive(4));
+        assert_eq!(buffs[1].target, BuffTarget::OnlySelf);
     }
 
     #[test]

--- a/crates/data/src/talent_buffs/pyro.rs
+++ b/crates/data/src/talent_buffs/pyro.rs
@@ -276,31 +276,31 @@ static KLEE_BUFFS: &[TalentBuffDef] = &[
 ];
 
 // ===== Mavuika =====
-// A1: ATK+30% for Nightsoul's Blessing party members
-// A4: ATK+60% max from Fighting Spirit (adopting max value)
+// A1 "Sunfrost Encomium": Mavuika's own ATK+30% while in Nightsoul's Blessing state
+// A4 "Fire-Forged Heritage" "Kiongozi": DMG Bonus +0.2% per Fighting Spirit point consumed (max +40% at C0, 200pt)
 static MAVUIKA_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Sunfrost Encomium ATK Bonus",
-        description: "A1: Party members under Nightsoul's Blessing gain ATK+30%",
+        description: "A1: Mavuika's own ATK+30% while in Nightsoul's Blessing state",
         stat: BuffableStat::AtkPercent,
         base_value: 0.30,
         scales_with_talent: false,
         talent_scaling: None,
         scales_on: None,
-        target: BuffTarget::Team,
+        target: BuffTarget::OnlySelf,
         source: TalentBuffSource::AscensionPassive(1),
         min_constellation: 0,
         cap: None,
     },
     TalentBuffDef {
-        name: "Fire-Forged Heritage ATK Bonus",
-        description: "A4: ATK bonus from Fighting Spirit consumed (max +60%, adopting max value)",
-        stat: BuffableStat::AtkPercent,
-        base_value: 0.60,
+        name: "Fire-Forged Heritage DMG Bonus",
+        description: "A4: DMG Bonus from Fighting Spirit consumed (max +40% at C0/200pt, adopting max value)",
+        stat: BuffableStat::DmgBonus,
+        base_value: 0.40,
         scales_with_talent: false,
         talent_scaling: None,
         scales_on: None,
-        target: BuffTarget::Team,
+        target: BuffTarget::OnlySelf,
         source: TalentBuffSource::AscensionPassive(4),
         min_constellation: 0,
         cap: None,


### PR DESCRIPTION
Fixes #32

## Changes

- **Xilonen skill RES scaling**: Fix table to correct values (9%+3%/lv, Lv1=9%, Lv15=51%)
- **Xilonen C4**: Replace incorrect EM+120 with DEF×65% flat DMG for Normal/Charged/Plunging
- **Mavuika A1**: Change target from Team to OnlySelf (self-buff only)
- **Mavuika A4**: Change AtkPercent 0.60 → DmgBonus 0.40 (C0 max 200pt×0.2%)
- **Citlali**: Replace incorrect A4 EM-scaling buff with correct C2 flat EM+250 for party

Generated with [Claude Code](https://claude.ai/code)