### PR TITLE
perf: reduce WASM binary size with descriptions feature gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@ target
 
 # Honey Hunter mirror (local cache, not tracked)
 honeyhunter-mirror/
-scripts/
+scripts/honeyhunter-mirror.sh
+scripts/honeyhunter-to-md.py

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "genshin-calc-core"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "glob",
  "serde",
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "genshin-calc-data"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "genshin-calc-core",
  "glob",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "genshin-calc-good"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "genshin-calc-core",
  "genshin-calc-data",
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "genshin-calc-wasm"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "console_error_panic_hook",
  "genshin-calc-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
 [workspace]
 members = ["crates/core", "crates/data", "crates/wasm", "crates/good"]
 resolver = "2"
+
+[profile.release]
+lto = true
+codegen-units = 1
+opt-level = "z"
+strip = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,6 +12,10 @@ exclude = ["tests/"]
 rust-version = "1.85"
 readme = "README.md"
 
+[features]
+default = ["descriptions"]
+descriptions = []
+
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genshin-calc-core"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2024"
 description = "Genshin Impact damage calculation engine"
 license = "MIT"

--- a/crates/data/Cargo.toml
+++ b/crates/data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genshin-calc-data"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2024"
 description = "Genshin Impact game data for genshin-calc"
 license = "MIT"
@@ -16,7 +16,7 @@ default = ["descriptions"]
 descriptions = ["genshin-calc-core/descriptions"]
 
 [dependencies]
-genshin-calc-core = { version = "0.5.11", path = "../core", default-features = false }
+genshin-calc-core = { version = "0.5.12", path = "../core", default-features = false }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/data/Cargo.toml
+++ b/crates/data/Cargo.toml
@@ -11,8 +11,12 @@ categories = ["game-engines", "data-structures"]
 rust-version = "1.85"
 readme = "README.md"
 
+[features]
+default = ["descriptions"]
+descriptions = ["genshin-calc-core/descriptions"]
+
 [dependencies]
-genshin-calc-core = { version = "0.5.11", path = "../core" }
+genshin-calc-core = { version = "0.5.11", path = "../core", default-features = false }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/data/src/artifacts.rs
+++ b/crates/data/src/artifacts.rs
@@ -18,7 +18,7 @@ pub const CRIMSON_WITCH: ArtifactSet = ArtifactSet {
     name: "燃え盛る炎の魔女",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "炎元素ダメージ+15%",
+        description: desc!("炎元素ダメージ+15%"),
         buffs: &[StatBuff {
             stat: BuffableStat::ElementalDmgBonus(Element::Pyro),
             value: 0.15,
@@ -27,12 +27,14 @@ pub const CRIMSON_WITCH: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "過負荷、燃焼、烈開花反応ダメージ+40%。蒸発、溶解反応倍率+15%。元素スキル使用後2セット効果+50%、最大3スタック",
+        description: desc!(
+            "過負荷、燃焼、烈開花反応ダメージ+40%。蒸発、溶解反応倍率+15%。元素スキル使用後2セット効果+50%、最大3スタック"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "cwof_pyro_stacks",
-                description: "Using Skill increases Pyro DMG by 7.5%, max 3 stacks",
+                description: desc!("Using Skill increases Pyro DMG by 7.5%, max 3 stacks"),
                 stat: BuffableStat::ElementalDmgBonus(Element::Pyro),
                 value: 0.075,
                 nightsoul_value: None,
@@ -43,7 +45,7 @@ pub const CRIMSON_WITCH: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "cw_amplifying",
-                description: "Vaporize/Melt reaction bonus +15%",
+                description: desc!("Vaporize/Melt reaction bonus +15%"),
                 stat: BuffableStat::AmplifyingBonus,
                 value: 0.15,
                 nightsoul_value: None,
@@ -54,7 +56,7 @@ pub const CRIMSON_WITCH: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "cw_transformative",
-                description: "Overloaded/Burning/Burgeon reaction DMG +40%",
+                description: desc!("Overloaded/Burning/Burgeon reaction DMG +40%"),
                 stat: BuffableStat::TransformativeBonus,
                 value: 0.40,
                 nightsoul_value: None,
@@ -72,7 +74,7 @@ pub const GLADIATORS_FINALE: ArtifactSet = ArtifactSet {
     name: "剣闘士のフィナーレ",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "攻撃力+18%",
+        description: desc!("攻撃力+18%"),
         buffs: &[StatBuff {
             stat: BuffableStat::AtkPercent,
             value: 0.18,
@@ -81,11 +83,13 @@ pub const GLADIATORS_FINALE: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "該当キャラクターが片手剣、両手剣、長柄武器キャラの場合、通常攻撃ダメージ+35%",
+        description: desc!(
+            "該当キャラクターが片手剣、両手剣、長柄武器キャラの場合、通常攻撃ダメージ+35%"
+        ),
         buffs: &[],
         conditional_buffs: &[ConditionalBuff {
             name: "gladiator_normal_bonus",
-            description: "Normal Attack DMG +35% for sword/claymore/polearm",
+            description: desc!("Normal Attack DMG +35% for sword/claymore/polearm"),
             stat: BuffableStat::NormalAtkDmgBonus,
             value: 0.35,
             nightsoul_value: None,
@@ -106,7 +110,7 @@ pub const WANDERERS_TROUPE: ArtifactSet = ArtifactSet {
     name: "大地を流浪する楽団",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "元素熟知+80",
+        description: desc!("元素熟知+80"),
         buffs: &[StatBuff {
             stat: BuffableStat::ElementalMastery,
             value: 80.0,
@@ -115,11 +119,11 @@ pub const WANDERERS_TROUPE: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "該当キャラクターが法器、弓キャラの場合、重撃ダメージ+35%",
+        description: desc!("該当キャラクターが法器、弓キャラの場合、重撃ダメージ+35%"),
         buffs: &[],
         conditional_buffs: &[ConditionalBuff {
             name: "wanderers_charged_bonus",
-            description: "Charged Attack DMG +35% for Catalyst/Bow users",
+            description: desc!("Charged Attack DMG +35% for Catalyst/Bow users"),
             stat: BuffableStat::ChargedAtkDmgBonus,
             value: 0.35,
             nightsoul_value: None,
@@ -139,7 +143,7 @@ pub const NOBLESSE_OBLIGE: ArtifactSet = ArtifactSet {
     name: "旧貴族のしつけ",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "元素爆発のダメージ+20%",
+        description: desc!("元素爆発のダメージ+20%"),
         buffs: &[StatBuff {
             stat: BuffableStat::BurstDmgBonus,
             value: 0.20,
@@ -148,11 +152,13 @@ pub const NOBLESSE_OBLIGE: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "元素爆発を発動すると、チーム全員の攻撃力+20%、継続時間12秒、重ねがけ不可",
+        description: desc!(
+            "元素爆発を発動すると、チーム全員の攻撃力+20%、継続時間12秒、重ねがけ不可"
+        ),
         buffs: &[],
         conditional_buffs: &[ConditionalBuff {
             name: "noblesse_atk_bonus",
-            description: "After using Elemental Burst, team ATK +20%",
+            description: desc!("After using Elemental Burst, team ATK +20%"),
             stat: BuffableStat::AtkPercent,
             value: 0.20,
             nightsoul_value: None,
@@ -169,7 +175,7 @@ pub const BLOODSTAINED_CHIVALRY: ArtifactSet = ArtifactSet {
     name: "血染めの騎士道",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "物理ダメージ+25%",
+        description: desc!("物理ダメージ+25%"),
         buffs: &[StatBuff {
             stat: BuffableStat::PhysicalDmgBonus,
             value: 0.25,
@@ -178,11 +184,11 @@ pub const BLOODSTAINED_CHIVALRY: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "敵を倒した10秒以内に、重撃のスタミナ消費-0、ダメージ+50%",
+        description: desc!("敵を倒した10秒以内に、重撃のスタミナ消費-0、ダメージ+50%"),
         buffs: &[],
         conditional_buffs: &[ConditionalBuff {
             name: "bloodstained_charged_bonus",
-            description: "After defeating enemy, Charged Attack DMG +50%",
+            description: desc!("After defeating enemy, Charged Attack DMG +50%"),
             stat: BuffableStat::ChargedAtkDmgBonus,
             value: 0.50,
             nightsoul_value: None,
@@ -199,7 +205,7 @@ pub const THUNDERING_FURY: ArtifactSet = ArtifactSet {
     name: "雷のような怒り",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "雷元素ダメージ+15%",
+        description: desc!("雷元素ダメージ+15%"),
         buffs: &[StatBuff {
             stat: BuffableStat::ElementalDmgBonus(Element::Electro),
             value: 0.15,
@@ -208,12 +214,16 @@ pub const THUNDERING_FURY: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "過負荷、感電、超電導、超激化反応ダメージ+40%。超開花反応ダメージ+20%。上記反応発生後、元素スキルのクールタイム-1秒。0.8秒ごとに1回のみ発動可能",
+        description: desc!(
+            "過負荷、感電、超電導、超激化反応ダメージ+40%。超開花反応ダメージ+20%。上記反応発生後、元素スキルのクールタイム-1秒。0.8秒ごとに1回のみ発動可能"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "tf_transformative",
-                description: "Electro reaction DMG (Overloaded/Superconduct/Electro-Charged/Hyperbloom) +40%",
+                description: desc!(
+                    "Electro reaction DMG (Overloaded/Superconduct/Electro-Charged/Hyperbloom) +40%"
+                ),
                 stat: BuffableStat::TransformativeBonus,
                 value: 0.40,
                 nightsoul_value: None,
@@ -224,7 +234,7 @@ pub const THUNDERING_FURY: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "tf_additive",
-                description: "Quicken reaction DMG (Aggravate/Spread) +20%",
+                description: desc!("Quicken reaction DMG (Aggravate/Spread) +20%"),
                 stat: BuffableStat::AdditiveBonus,
                 value: 0.20,
                 nightsoul_value: None,
@@ -242,7 +252,7 @@ pub const THUNDERSOOTHER: ArtifactSet = ArtifactSet {
     name: "雷を鎮める尊者",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "雷元素耐性+40%",
+        description: desc!("雷元素耐性+40%"),
         buffs: &[StatBuff {
             stat: BuffableStat::ElementalRes(Element::Electro),
             value: 0.40,
@@ -251,11 +261,11 @@ pub const THUNDERSOOTHER: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "雷元素の影響を受けた敵に対するダメージ+35%",
+        description: desc!("雷元素の影響を受けた敵に対するダメージ+35%"),
         buffs: &[],
         conditional_buffs: &[ConditionalBuff {
             name: "thundersoother_dmg_bonus",
-            description: "DMG +35% against enemies affected by Electro",
+            description: desc!("DMG +35% against enemies affected by Electro"),
             stat: BuffableStat::DmgBonus,
             value: 0.35,
             nightsoul_value: None,
@@ -272,7 +282,7 @@ pub const VIRIDESCENT_VENERER: ArtifactSet = ArtifactSet {
     name: "翠緑の影",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "風元素ダメージ+15%",
+        description: desc!("風元素ダメージ+15%"),
         buffs: &[StatBuff {
             stat: BuffableStat::ElementalDmgBonus(Element::Anemo),
             value: 0.15,
@@ -281,12 +291,14 @@ pub const VIRIDESCENT_VENERER: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "拡散反応ダメージ+60%。拡散反応に対応する元素の敵耐性-40%、継続時間10秒",
+        description: desc!(
+            "拡散反応ダメージ+60%。拡散反応に対応する元素の敵耐性-40%、継続時間10秒"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "vv_swirl_bonus",
-                description: "Swirl DMG +60%",
+                description: desc!("Swirl DMG +60%"),
                 stat: BuffableStat::TransformativeBonus,
                 value: 0.60,
                 nightsoul_value: None,
@@ -297,7 +309,7 @@ pub const VIRIDESCENT_VENERER: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "vv_res_shred_pyro",
-                description: "Enemy Pyro RES -40%",
+                description: desc!("Enemy Pyro RES -40%"),
                 stat: BuffableStat::ElementalResReduction(Element::Pyro),
                 value: 0.40,
                 nightsoul_value: None,
@@ -308,7 +320,7 @@ pub const VIRIDESCENT_VENERER: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "vv_res_shred_hydro",
-                description: "Enemy Hydro RES -40%",
+                description: desc!("Enemy Hydro RES -40%"),
                 stat: BuffableStat::ElementalResReduction(Element::Hydro),
                 value: 0.40,
                 nightsoul_value: None,
@@ -319,7 +331,7 @@ pub const VIRIDESCENT_VENERER: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "vv_res_shred_electro",
-                description: "Enemy Electro RES -40%",
+                description: desc!("Enemy Electro RES -40%"),
                 stat: BuffableStat::ElementalResReduction(Element::Electro),
                 value: 0.40,
                 nightsoul_value: None,
@@ -330,7 +342,7 @@ pub const VIRIDESCENT_VENERER: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "vv_res_shred_cryo",
-                description: "Enemy Cryo RES -40%",
+                description: desc!("Enemy Cryo RES -40%"),
                 stat: BuffableStat::ElementalResReduction(Element::Cryo),
                 value: 0.40,
                 nightsoul_value: None,
@@ -348,7 +360,7 @@ pub const MAIDEN_BELOVED: ArtifactSet = ArtifactSet {
     name: "愛される少女",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "与える治療効果+15%",
+        description: desc!("与える治療効果+15%"),
         buffs: &[StatBuff {
             stat: BuffableStat::HealingBonus,
             value: 0.15,
@@ -357,7 +369,9 @@ pub const MAIDEN_BELOVED: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "元素スキルまたは元素爆発を発動した後10秒間、チーム全員が受ける治療効果+20%",
+        description: desc!(
+            "元素スキルまたは元素爆発を発動した後10秒間、チーム全員が受ける治療効果+20%"
+        ),
         buffs: &[],
         conditional_buffs: &[],
     },
@@ -368,7 +382,7 @@ pub const ARCHAIC_PETRA: ArtifactSet = ArtifactSet {
     name: "悠久の磐岩",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "岩元素ダメージ+15%",
+        description: desc!("岩元素ダメージ+15%"),
         buffs: &[StatBuff {
             stat: BuffableStat::ElementalDmgBonus(Element::Geo),
             value: 0.15,
@@ -377,12 +391,14 @@ pub const ARCHAIC_PETRA: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "結晶反応で形成された欠片を獲得すると、チーム全員の該当元素ダメージ+35%、継続時間10秒。同時に1つの元素ダメージボーナスのみ獲得可能",
+        description: desc!(
+            "結晶反応で形成された欠片を獲得すると、チーム全員の該当元素ダメージ+35%、継続時間10秒。同時に1つの元素ダメージボーナスのみ獲得可能"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "archaic_petra_pyro",
-                description: "Pyro Crystallize shard: team Pyro DMG +35%",
+                description: desc!("Pyro Crystallize shard: team Pyro DMG +35%"),
                 stat: BuffableStat::ElementalDmgBonus(Element::Pyro),
                 value: 0.35,
                 nightsoul_value: None,
@@ -393,7 +409,7 @@ pub const ARCHAIC_PETRA: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "archaic_petra_hydro",
-                description: "Hydro Crystallize shard: team Hydro DMG +35%",
+                description: desc!("Hydro Crystallize shard: team Hydro DMG +35%"),
                 stat: BuffableStat::ElementalDmgBonus(Element::Hydro),
                 value: 0.35,
                 nightsoul_value: None,
@@ -404,7 +420,7 @@ pub const ARCHAIC_PETRA: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "archaic_petra_electro",
-                description: "Electro Crystallize shard: team Electro DMG +35%",
+                description: desc!("Electro Crystallize shard: team Electro DMG +35%"),
                 stat: BuffableStat::ElementalDmgBonus(Element::Electro),
                 value: 0.35,
                 nightsoul_value: None,
@@ -415,7 +431,7 @@ pub const ARCHAIC_PETRA: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "archaic_petra_cryo",
-                description: "Cryo Crystallize shard: team Cryo DMG +35%",
+                description: desc!("Cryo Crystallize shard: team Cryo DMG +35%"),
                 stat: BuffableStat::ElementalDmgBonus(Element::Cryo),
                 value: 0.35,
                 nightsoul_value: None,
@@ -433,7 +449,7 @@ pub const RETRACING_BOLIDE: ArtifactSet = ArtifactSet {
     name: "逆飛びの流星",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "シールド強化+35%",
+        description: desc!("シールド強化+35%"),
         buffs: &[StatBuff {
             stat: BuffableStat::ShieldStrength,
             value: 0.35,
@@ -442,12 +458,12 @@ pub const RETRACING_BOLIDE: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "シールド状態の時、通常攻撃と重撃ダメージ+40%",
+        description: desc!("シールド状態の時、通常攻撃と重撃ダメージ+40%"),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "bolide_normal_charged_bonus",
-                description: "While shielded, Normal and Charged Attack DMG +40%",
+                description: desc!("While shielded, Normal and Charged Attack DMG +40%"),
                 stat: BuffableStat::NormalAtkDmgBonus,
                 value: 0.40,
                 nightsoul_value: None,
@@ -458,7 +474,7 @@ pub const RETRACING_BOLIDE: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "bolide_charged_bonus",
-                description: "While shielded, Charged Attack DMG +40%",
+                description: desc!("While shielded, Charged Attack DMG +40%"),
                 stat: BuffableStat::ChargedAtkDmgBonus,
                 value: 0.40,
                 nightsoul_value: None,
@@ -476,7 +492,7 @@ pub const LAVAWALKER: ArtifactSet = ArtifactSet {
     name: "烈火を渡る賢者",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "炎元素耐性+40%",
+        description: desc!("炎元素耐性+40%"),
         buffs: &[StatBuff {
             stat: BuffableStat::ElementalRes(Element::Pyro),
             value: 0.40,
@@ -485,11 +501,11 @@ pub const LAVAWALKER: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "炎元素の影響を受けた敵に対するダメージ+35%",
+        description: desc!("炎元素の影響を受けた敵に対するダメージ+35%"),
         buffs: &[],
         conditional_buffs: &[ConditionalBuff {
             name: "lavawalker_dmg_bonus",
-            description: "DMG +35% against enemies affected by Pyro",
+            description: desc!("DMG +35% against enemies affected by Pyro"),
             stat: BuffableStat::DmgBonus,
             value: 0.35,
             nightsoul_value: None,
@@ -506,7 +522,7 @@ pub const BLIZZARD_STRAYER: ArtifactSet = ArtifactSet {
     name: "氷風を彷徨う勇士",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "氷元素ダメージ+15%",
+        description: desc!("氷元素ダメージ+15%"),
         buffs: &[StatBuff {
             stat: BuffableStat::ElementalDmgBonus(Element::Cryo),
             value: 0.15,
@@ -515,12 +531,14 @@ pub const BLIZZARD_STRAYER: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "氷元素の影響を受けた敵を攻撃した場合、会心率+20%。敵が凍結状態の場合、会心率は更に+20%",
+        description: desc!(
+            "氷元素の影響を受けた敵を攻撃した場合、会心率+20%。敵が凍結状態の場合、会心率は更に+20%"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "blizzard_crit_cryo",
-                description: "Crit Rate +20% vs Cryo-affected enemies (1 stack)",
+                description: desc!("Crit Rate +20% vs Cryo-affected enemies (1 stack)"),
                 stat: BuffableStat::CritRate,
                 value: 0.20,
                 nightsoul_value: None,
@@ -531,7 +549,7 @@ pub const BLIZZARD_STRAYER: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "blizzard_crit_frozen",
-                description: "Crit Rate +20% vs Frozen enemies (additional, 2nd stack)",
+                description: desc!("Crit Rate +20% vs Frozen enemies (additional, 2nd stack)"),
                 stat: BuffableStat::CritRate,
                 value: 0.20,
                 nightsoul_value: None,
@@ -549,7 +567,7 @@ pub const HEART_OF_DEPTH: ArtifactSet = ArtifactSet {
     name: "沈淪の心",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "水元素ダメージ+15%",
+        description: desc!("水元素ダメージ+15%"),
         buffs: &[StatBuff {
             stat: BuffableStat::ElementalDmgBonus(Element::Hydro),
             value: 0.15,
@@ -558,12 +576,12 @@ pub const HEART_OF_DEPTH: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "元素スキル発動後15秒間、通常攻撃と重撃のダメージ+30%",
+        description: desc!("元素スキル発動後15秒間、通常攻撃と重撃のダメージ+30%"),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "hod_normal_bonus",
-                description: "After using Elemental Skill, Normal Attack DMG +30%",
+                description: desc!("After using Elemental Skill, Normal Attack DMG +30%"),
                 stat: BuffableStat::NormalAtkDmgBonus,
                 value: 0.30,
                 nightsoul_value: None,
@@ -574,7 +592,7 @@ pub const HEART_OF_DEPTH: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "hod_charged_bonus",
-                description: "After using Elemental Skill, Charged Attack DMG +30%",
+                description: desc!("After using Elemental Skill, Charged Attack DMG +30%"),
                 stat: BuffableStat::ChargedAtkDmgBonus,
                 value: 0.30,
                 nightsoul_value: None,
@@ -592,7 +610,7 @@ pub const TENACITY_OF_THE_MILLELITH: ArtifactSet = ArtifactSet {
     name: "千岩牢固",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "HP+20%",
+        description: desc!("HP+20%"),
         buffs: &[StatBuff {
             stat: BuffableStat::HpPercent,
             value: 0.20,
@@ -601,12 +619,14 @@ pub const TENACITY_OF_THE_MILLELITH: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "元素スキルが敵に命中すると、周囲のチーム全員の攻撃力+20%、シールド強化+30%、継続時間3秒。0.5秒ごとに1回のみ発動可能。この効果はキャラクターが待機中でも発動可能",
+        description: desc!(
+            "元素スキルが敵に命中すると、周囲のチーム全員の攻撃力+20%、シールド強化+30%、継続時間3秒。0.5秒ごとに1回のみ発動可能。この効果はキャラクターが待機中でも発動可能"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "millelith_atk_bonus",
-                description: "After Skill hits, team ATK +20%",
+                description: desc!("After Skill hits, team ATK +20%"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.20,
                 nightsoul_value: None,
@@ -617,7 +637,7 @@ pub const TENACITY_OF_THE_MILLELITH: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "millelith_shield_bonus",
-                description: "After Skill hits, team Shield Strength +30%",
+                description: desc!("After Skill hits, team Shield Strength +30%"),
                 stat: BuffableStat::ShieldStrength,
                 value: 0.30,
                 nightsoul_value: None,
@@ -635,7 +655,7 @@ pub const PALE_FLAME: ArtifactSet = ArtifactSet {
     name: "蒼白の炎",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "物理ダメージ+25%",
+        description: desc!("物理ダメージ+25%"),
         buffs: &[StatBuff {
             stat: BuffableStat::PhysicalDmgBonus,
             value: 0.25,
@@ -644,12 +664,14 @@ pub const PALE_FLAME: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "元素スキルが敵に命中すると、攻撃力+9%、継続時間7秒、最大2スタック。2スタック時に2セットの効果+100%",
+        description: desc!(
+            "元素スキルが敵に命中すると、攻撃力+9%、継続時間7秒、最大2スタック。2スタック時に2セットの効果+100%"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "pale_flame_atk_stacks",
-                description: "Skill hit: ATK +9% per stack, max 2",
+                description: desc!("Skill hit: ATK +9% per stack, max 2"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.09,
                 nightsoul_value: None,
@@ -660,7 +682,7 @@ pub const PALE_FLAME: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "pale_flame_phys_bonus",
-                description: "At 2 stacks, Physical DMG +25% (2pc effect doubled)",
+                description: desc!("At 2 stacks, Physical DMG +25% (2pc effect doubled)"),
                 stat: BuffableStat::PhysicalDmgBonus,
                 value: 0.25,
                 nightsoul_value: None,
@@ -678,7 +700,7 @@ pub const SHIMENAWAS_REMINISCENCE: ArtifactSet = ArtifactSet {
     name: "追憶のしめ縄",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "攻撃力+18%",
+        description: desc!("攻撃力+18%"),
         buffs: &[StatBuff {
             stat: BuffableStat::AtkPercent,
             value: 0.18,
@@ -687,12 +709,14 @@ pub const SHIMENAWAS_REMINISCENCE: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "元素スキルを発動した時、元素エネルギーが15以上の場合、元素エネルギーを15消費し、通常攻撃、重撃、落下攻撃ダメージ+50%、継続時間10秒。この効果は継続時間中に再発動不可",
+        description: desc!(
+            "元素スキルを発動した時、元素エネルギーが15以上の場合、元素エネルギーを15消費し、通常攻撃、重撃、落下攻撃ダメージ+50%、継続時間10秒。この効果は継続時間中に再発動不可"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "shimenawa_normal_bonus",
-                description: "After Skill use (15 energy consumed), Normal Attack DMG +50%",
+                description: desc!("After Skill use (15 energy consumed), Normal Attack DMG +50%"),
                 stat: BuffableStat::NormalAtkDmgBonus,
                 value: 0.50,
                 nightsoul_value: None,
@@ -703,7 +727,7 @@ pub const SHIMENAWAS_REMINISCENCE: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "shimenawa_charged_bonus",
-                description: "After Skill use (15 energy consumed), Charged Attack DMG +50%",
+                description: desc!("After Skill use (15 energy consumed), Charged Attack DMG +50%"),
                 stat: BuffableStat::ChargedAtkDmgBonus,
                 value: 0.50,
                 nightsoul_value: None,
@@ -714,7 +738,9 @@ pub const SHIMENAWAS_REMINISCENCE: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "shimenawa_plunging_bonus",
-                description: "After Skill use (15 energy consumed), Plunging Attack DMG +50%",
+                description: desc!(
+                    "After Skill use (15 energy consumed), Plunging Attack DMG +50%"
+                ),
                 stat: BuffableStat::PlungingAtkDmgBonus,
                 value: 0.50,
                 nightsoul_value: None,
@@ -732,7 +758,7 @@ pub const EMBLEM_OF_SEVERED_FATE: ArtifactSet = ArtifactSet {
     name: "絶縁の旗印",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "元素チャージ効率+20%",
+        description: desc!("元素チャージ効率+20%"),
         buffs: &[StatBuff {
             stat: BuffableStat::EnergyRecharge,
             value: 0.20,
@@ -741,11 +767,13 @@ pub const EMBLEM_OF_SEVERED_FATE: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "元素チャージ効率の25%を基準に、元素爆発のダメージがアップする。この方式でアップできるダメージは最大75%まで",
+        description: desc!(
+            "元素チャージ効率の25%を基準に、元素爆発のダメージがアップする。この方式でアップできるダメージは最大75%まで"
+        ),
         buffs: &[],
         conditional_buffs: &[ConditionalBuff {
             name: "emblem_burst_bonus",
-            description: "Burst DMG +25% of Energy Recharge, max 75%",
+            description: desc!("Burst DMG +25% of Energy Recharge, max 75%"),
             stat: BuffableStat::BurstDmgBonus,
             value: 0.25,
             nightsoul_value: None,
@@ -766,7 +794,7 @@ pub const HUSK_OF_OPULENT_DREAMS: ArtifactSet = ArtifactSet {
     name: "華館夢醒形骸記",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "防御力+30%",
+        description: desc!("防御力+30%"),
         buffs: &[StatBuff {
             stat: BuffableStat::DefPercent,
             value: 0.30,
@@ -775,12 +803,14 @@ pub const HUSK_OF_OPULENT_DREAMS: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "装備キャラクターがフィールドにいる時、岩元素ダメージを与えた0.3秒後に「問答」スタックを1獲得、最大4スタック。1スタックにつき防御力+6%と岩元素ダメージ+6%。6秒ごとに「問答」スタックを獲得できない場合、スタック-1。装備キャラクターが待機中の場合、3秒ごとに「問答」スタック+1",
+        description: desc!(
+            "装備キャラクターがフィールドにいる時、岩元素ダメージを与えた0.3秒後に「問答」スタックを1獲得、最大4スタック。1スタックにつき防御力+6%と岩元素ダメージ+6%。6秒ごとに「問答」スタックを獲得できない場合、スタック-1。装備キャラクターが待機中の場合、3秒ごとに「問答」スタック+1"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "husk_def_stacks",
-                description: "Curiosity stack: DEF +6% per stack, max 4",
+                description: desc!("Curiosity stack: DEF +6% per stack, max 4"),
                 stat: BuffableStat::DefPercent,
                 value: 0.06,
                 nightsoul_value: None,
@@ -791,7 +821,7 @@ pub const HUSK_OF_OPULENT_DREAMS: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "husk_geo_stacks",
-                description: "Curiosity stack: Geo DMG +6% per stack, max 4",
+                description: desc!("Curiosity stack: Geo DMG +6% per stack, max 4"),
                 stat: BuffableStat::ElementalDmgBonus(Element::Geo),
                 value: 0.06,
                 nightsoul_value: None,
@@ -809,7 +839,7 @@ pub const OCEAN_HUED_CLAM: ArtifactSet = ArtifactSet {
     name: "海染硨磲",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "与える治療効果+15%",
+        description: desc!("与える治療効果+15%"),
         buffs: &[StatBuff {
             stat: BuffableStat::HealingBonus,
             value: 0.15,
@@ -818,7 +848,9 @@ pub const OCEAN_HUED_CLAM: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "装備キャラクターが治療を行うと「海染の泡」が生成され、3秒間治療量を蓄積する。蓄積時間終了時、泡が破裂し周囲の敵にHP回復量の90%分のダメージを与える（物理ダメージ）。最大30000まで蓄積可能",
+        description: desc!(
+            "装備キャラクターが治療を行うと「海染の泡」が生成され、3秒間治療量を蓄積する。蓄積時間終了時、泡が破裂し周囲の敵にHP回復量の90%分のダメージを与える（物理ダメージ）。最大30000まで蓄積可能"
+        ),
         buffs: &[],
         conditional_buffs: &[],
     },
@@ -829,7 +861,7 @@ pub const VERMILLION_HEREAFTER: ArtifactSet = ArtifactSet {
     name: "辰砂往生録",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "攻撃力+18%",
+        description: desc!("攻撃力+18%"),
         buffs: &[StatBuff {
             stat: BuffableStat::AtkPercent,
             value: 0.18,
@@ -838,12 +870,14 @@ pub const VERMILLION_HEREAFTER: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "元素爆発を発動した後、攻撃力+8%。さらにHPが減少するたびに攻撃力+10%、最大4スタック。この効果は継続時間16秒。HPが増加した場合もスタック解除されない。スタック数は0.8秒に最大1回のみ変動",
+        description: desc!(
+            "元素爆発を発動した後、攻撃力+8%。さらにHPが減少するたびに攻撃力+10%、最大4スタック。この効果は継続時間16秒。HPが増加した場合もスタック解除されない。スタック数は0.8秒に最大1回のみ変動"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "vermillion_atk_base",
-                description: "After Elemental Burst, ATK +8%",
+                description: desc!("After Elemental Burst, ATK +8%"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.08,
                 nightsoul_value: None,
@@ -854,7 +888,7 @@ pub const VERMILLION_HEREAFTER: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "vermillion_atk_stacks",
-                description: "HP decreases: ATK +10% per stack, max 4",
+                description: desc!("HP decreases: ATK +10% per stack, max 4"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.10,
                 nightsoul_value: None,
@@ -872,7 +906,7 @@ pub const ECHOES_OF_AN_OFFERING: ArtifactSet = ArtifactSet {
     name: "来歆の余響",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "攻撃力+18%",
+        description: desc!("攻撃力+18%"),
         buffs: &[StatBuff {
             stat: BuffableStat::AtkPercent,
             value: 0.18,
@@ -881,11 +915,13 @@ pub const ECHOES_OF_AN_OFFERING: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "通常攻撃が命中した時、36%の確率で「谷の念」が発動し、通常攻撃のダメージが攻撃力の70%分アップする。発動しなかった場合、次回の発動確率+20%。0.2秒ごとに1回のみ判定",
+        description: desc!(
+            "通常攻撃が命中した時、36%の確率で「谷の念」が発動し、通常攻撃のダメージが攻撃力の70%分アップする。発動しなかった場合、次回の発動確率+20%。0.2秒ごとに1回のみ判定"
+        ),
         buffs: &[],
         conditional_buffs: &[ConditionalBuff {
             name: "echoes_valley_rite",
-            description: "Valley Rite: Normal ATK flat DMG +70% of ATK",
+            description: desc!("Valley Rite: Normal ATK flat DMG +70% of ATK"),
             stat: BuffableStat::NormalAtkFlatDmg,
             value: 0.70,
             nightsoul_value: None,
@@ -909,7 +945,7 @@ pub const DEEPWOOD_MEMORIES: ArtifactSet = ArtifactSet {
     name: "深林の記憶",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "草元素ダメージ+15%",
+        description: desc!("草元素ダメージ+15%"),
         buffs: &[StatBuff {
             stat: BuffableStat::ElementalDmgBonus(Element::Dendro),
             value: 0.15,
@@ -918,11 +954,13 @@ pub const DEEPWOOD_MEMORIES: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "元素スキルまたは元素爆発が敵に命中した後、敵の草元素耐性-30%、継続時間8秒。装備キャラクターが待機中でも効果を発動可能",
+        description: desc!(
+            "元素スキルまたは元素爆発が敵に命中した後、敵の草元素耐性-30%、継続時間8秒。装備キャラクターが待機中でも効果を発動可能"
+        ),
         buffs: &[],
         conditional_buffs: &[ConditionalBuff {
             name: "deepwood_dendro_res_shred",
-            description: "After Skill/Burst hit, enemy Dendro RES -30%",
+            description: desc!("After Skill/Burst hit, enemy Dendro RES -30%"),
             stat: BuffableStat::ElementalResReduction(Element::Dendro),
             value: 0.30,
             nightsoul_value: None,
@@ -939,7 +977,7 @@ pub const GILDED_DREAMS: ArtifactSet = ArtifactSet {
     name: "金メッキの夢",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "元素熟知+80",
+        description: desc!("元素熟知+80"),
         buffs: &[StatBuff {
             stat: BuffableStat::ElementalMastery,
             value: 80.0,
@@ -948,12 +986,14 @@ pub const GILDED_DREAMS: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "元素反応を起こした後8秒間、チーム内の自身以外のキャラクターの元素タイプに応じてバフを獲得。自身と同じ元素タイプのキャラ1人につき攻撃力+14%、異なる元素タイプのキャラ1人につき元素熟知+50。上記効果は最大3人分まで。0.8秒ごとに1回のみ発動可能。待機中でも効果を発動可能",
+        description: desc!(
+            "元素反応を起こした後8秒間、チーム内の自身以外のキャラクターの元素タイプに応じてバフを獲得。自身と同じ元素タイプのキャラ1人につき攻撃力+14%、異なる元素タイプのキャラ1人につき元素熟知+50。上記効果は最大3人分まで。0.8秒ごとに1回のみ発動可能。待機中でも効果を発動可能"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "gilded_same1_atk",
-                description: "1 same-element teammate: ATK +14%",
+                description: desc!("1 same-element teammate: ATK +14%"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.14,
                 nightsoul_value: None,
@@ -964,7 +1004,7 @@ pub const GILDED_DREAMS: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "gilded_same2_atk",
-                description: "2 same-element teammates: ATK +14%",
+                description: desc!("2 same-element teammates: ATK +14%"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.14,
                 nightsoul_value: None,
@@ -975,7 +1015,7 @@ pub const GILDED_DREAMS: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "gilded_same3_atk",
-                description: "3 same-element teammates: ATK +14%",
+                description: desc!("3 same-element teammates: ATK +14%"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.14,
                 nightsoul_value: None,
@@ -986,7 +1026,7 @@ pub const GILDED_DREAMS: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "gilded_diff1_em",
-                description: "1 different-element teammate: EM +50",
+                description: desc!("1 different-element teammate: EM +50"),
                 stat: BuffableStat::ElementalMastery,
                 value: 50.0,
                 nightsoul_value: None,
@@ -997,7 +1037,7 @@ pub const GILDED_DREAMS: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "gilded_diff2_em",
-                description: "2 different-element teammates: EM +50",
+                description: desc!("2 different-element teammates: EM +50"),
                 stat: BuffableStat::ElementalMastery,
                 value: 50.0,
                 nightsoul_value: None,
@@ -1008,7 +1048,7 @@ pub const GILDED_DREAMS: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "gilded_diff3_em",
-                description: "3 different-element teammates: EM +50",
+                description: desc!("3 different-element teammates: EM +50"),
                 stat: BuffableStat::ElementalMastery,
                 value: 50.0,
                 nightsoul_value: None,
@@ -1026,7 +1066,7 @@ pub const DESERT_PAVILION_CHRONICLE: ArtifactSet = ArtifactSet {
     name: "砂上の楼閣の史話",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "風元素ダメージ+15%",
+        description: desc!("風元素ダメージ+15%"),
         buffs: &[StatBuff {
             stat: BuffableStat::ElementalDmgBonus(Element::Anemo),
             value: 0.15,
@@ -1035,12 +1075,14 @@ pub const DESERT_PAVILION_CHRONICLE: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "重撃が敵に命中すると、通常攻撃の攻撃速度+10%、通常攻撃、重撃、落下攻撃のダメージ+40%、継続時間15秒",
+        description: desc!(
+            "重撃が敵に命中すると、通常攻撃の攻撃速度+10%、通常攻撃、重撃、落下攻撃のダメージ+40%、継続時間15秒"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "desert_pavilion_normal_bonus",
-                description: "After Charged Attack hits, Normal Attack DMG +40%",
+                description: desc!("After Charged Attack hits, Normal Attack DMG +40%"),
                 stat: BuffableStat::NormalAtkDmgBonus,
                 value: 0.40,
                 nightsoul_value: None,
@@ -1051,7 +1093,7 @@ pub const DESERT_PAVILION_CHRONICLE: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "desert_pavilion_charged_bonus",
-                description: "After Charged Attack hits, Charged Attack DMG +40%",
+                description: desc!("After Charged Attack hits, Charged Attack DMG +40%"),
                 stat: BuffableStat::ChargedAtkDmgBonus,
                 value: 0.40,
                 nightsoul_value: None,
@@ -1062,7 +1104,7 @@ pub const DESERT_PAVILION_CHRONICLE: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "desert_pavilion_plunging_bonus",
-                description: "After Charged Attack hits, Plunging Attack DMG +40%",
+                description: desc!("After Charged Attack hits, Plunging Attack DMG +40%"),
                 stat: BuffableStat::PlungingAtkDmgBonus,
                 value: 0.40,
                 nightsoul_value: None,
@@ -1080,7 +1122,7 @@ pub const FLOWER_OF_PARADISE_LOST: ArtifactSet = ArtifactSet {
     name: "楽園の絶花",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "元素熟知+80",
+        description: desc!("元素熟知+80"),
         buffs: &[StatBuff {
             stat: BuffableStat::ElementalMastery,
             value: 80.0,
@@ -1089,12 +1131,14 @@ pub const FLOWER_OF_PARADISE_LOST: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "開花、超開花、烈開花反応ダメージ+40%。さらに装備キャラクターが開花、超開花、烈開花反応を起こした後、上記効果+25%、最大4スタック、継続時間10秒。0.8秒ごとに1回のみスタック獲得可能。待機中でも効果を発動可能",
+        description: desc!(
+            "開花、超開花、烈開花反応ダメージ+40%。さらに装備キャラクターが開花、超開花、烈開花反応を起こした後、上記効果+25%、最大4スタック、継続時間10秒。0.8秒ごとに1回のみスタック獲得可能。待機中でも効果を発動可能"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "fopl_bloom_base",
-                description: "Bloom/Hyperbloom/Burgeon DMG +40%",
+                description: desc!("Bloom/Hyperbloom/Burgeon DMG +40%"),
                 stat: BuffableStat::TransformativeBonus,
                 value: 0.40,
                 nightsoul_value: None,
@@ -1105,7 +1149,7 @@ pub const FLOWER_OF_PARADISE_LOST: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "fopl_bloom_stacks",
-                description: "After triggering Bloom reaction, +10% per stack, max 4",
+                description: desc!("After triggering Bloom reaction, +10% per stack, max 4"),
                 stat: BuffableStat::TransformativeBonus,
                 value: 0.10,
                 nightsoul_value: None,
@@ -1123,7 +1167,7 @@ pub const NYMPHS_DREAM: ArtifactSet = ArtifactSet {
     name: "水仙の夢",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "水元素ダメージ+15%",
+        description: desc!("水元素ダメージ+15%"),
         buffs: &[StatBuff {
             stat: BuffableStat::ElementalDmgBonus(Element::Hydro),
             value: 0.15,
@@ -1132,12 +1176,14 @@ pub const NYMPHS_DREAM: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "通常攻撃、重撃、元素スキル、元素爆発が命中した後、1/2/3スタックでそれぞれ水元素ダメージ+7%/16%/25%、攻撃力+4%/9%/15%。各攻撃が命中するたびに、他種類のスタックの持続時間をリセット。各種類のスタックは0.8秒に1回のみ獲得可能",
+        description: desc!(
+            "通常攻撃、重撃、元素スキル、元素爆発が命中した後、1/2/3スタックでそれぞれ水元素ダメージ+7%/16%/25%、攻撃力+4%/9%/15%。各攻撃が命中するたびに、他種類のスタックの持続時間をリセット。各種類のスタックは0.8秒に1回のみ獲得可能"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "nymphs_dream_atk_stacks",
-                description: "Attack hits: ATK +4%/9%/15% at 1/2/3 stacks",
+                description: desc!("Attack hits: ATK +4%/9%/15% at 1/2/3 stacks"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.04,
                 nightsoul_value: None,
@@ -1148,7 +1194,7 @@ pub const NYMPHS_DREAM: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "nymphs_dream_hydro_stacks",
-                description: "Attack hits: Hydro DMG +7%/16%/25% at 1/2/3 stacks",
+                description: desc!("Attack hits: Hydro DMG +7%/16%/25% at 1/2/3 stacks"),
                 stat: BuffableStat::ElementalDmgBonus(Element::Hydro),
                 value: 0.07,
                 nightsoul_value: None,
@@ -1166,7 +1212,7 @@ pub const VOURUKASHAS_GLOW: ArtifactSet = ArtifactSet {
     name: "花海甘露の光",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "HP+20%",
+        description: desc!("HP+20%"),
         buffs: &[StatBuff {
             stat: BuffableStat::HpPercent,
             value: 0.20,
@@ -1175,7 +1221,9 @@ pub const VOURUKASHAS_GLOW: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "元素スキルと元素爆発のダメージ+10%。装備キャラクターがダメージを受けた後、上記効果+80%、継続時間5秒、最大5スタック。各スタックの持続時間は独立。待機中でも効果を発動可能",
+        description: desc!(
+            "元素スキルと元素爆発のダメージ+10%。装備キャラクターがダメージを受けた後、上記効果+80%、継続時間5秒、最大5スタック。各スタックの持続時間は独立。待機中でも効果を発動可能"
+        ),
         buffs: &[
             StatBuff {
                 stat: BuffableStat::SkillDmgBonus,
@@ -1191,7 +1239,7 @@ pub const VOURUKASHAS_GLOW: ArtifactSet = ArtifactSet {
         conditional_buffs: &[
             ConditionalBuff {
                 name: "vourukasha_skill_stacks",
-                description: "After taking DMG: Skill DMG +8% per stack, max 5",
+                description: desc!("After taking DMG: Skill DMG +8% per stack, max 5"),
                 stat: BuffableStat::SkillDmgBonus,
                 value: 0.08,
                 nightsoul_value: None,
@@ -1202,7 +1250,7 @@ pub const VOURUKASHAS_GLOW: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "vourukasha_burst_stacks",
-                description: "After taking DMG: Burst DMG +8% per stack, max 5",
+                description: desc!("After taking DMG: Burst DMG +8% per stack, max 5"),
                 stat: BuffableStat::BurstDmgBonus,
                 value: 0.08,
                 nightsoul_value: None,
@@ -1220,7 +1268,7 @@ pub const MARECHAUSSEE_HUNTER: ArtifactSet = ArtifactSet {
     name: "ファントムハンター",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "通常攻撃と重撃ダメージ+15%",
+        description: desc!("通常攻撃と重撃ダメージ+15%"),
         buffs: &[
             StatBuff {
                 stat: BuffableStat::NormalAtkDmgBonus,
@@ -1236,11 +1284,11 @@ pub const MARECHAUSSEE_HUNTER: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "現在のHPが変動した後、会心率+12%、継続時間5秒、最大3スタック",
+        description: desc!("現在のHPが変動した後、会心率+12%、継続時間5秒、最大3スタック"),
         buffs: &[],
         conditional_buffs: &[ConditionalBuff {
             name: "marechaussee_crit_stacks",
-            description: "HP changes: Crit Rate +12% per stack, max 3",
+            description: desc!("HP changes: Crit Rate +12% per stack, max 3"),
             stat: BuffableStat::CritRate,
             value: 0.12,
             nightsoul_value: None,
@@ -1257,7 +1305,7 @@ pub const GOLDEN_TROUPE: ArtifactSet = ArtifactSet {
     name: "黄金の劇団",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "元素スキルのダメージ+20%",
+        description: desc!("元素スキルのダメージ+20%"),
         buffs: &[StatBuff {
             stat: BuffableStat::SkillDmgBonus,
             value: 0.20,
@@ -1266,7 +1314,9 @@ pub const GOLDEN_TROUPE: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "元素スキルのダメージ+25%。さらにキャラクターが待機中の場合、元素スキルのダメージ+25%",
+        description: desc!(
+            "元素スキルのダメージ+25%。さらにキャラクターが待機中の場合、元素スキルのダメージ+25%"
+        ),
         buffs: &[StatBuff {
             stat: BuffableStat::SkillDmgBonus,
             value: 0.25,
@@ -1274,7 +1324,7 @@ pub const GOLDEN_TROUPE: ArtifactSet = ArtifactSet {
         }],
         conditional_buffs: &[ConditionalBuff {
             name: "golden_troupe_off_field_bonus",
-            description: "While off-field, Skill DMG +25%",
+            description: desc!("While off-field, Skill DMG +25%"),
             stat: BuffableStat::SkillDmgBonus,
             value: 0.25,
             nightsoul_value: None,
@@ -1291,7 +1341,7 @@ pub const SONG_OF_DAYS_PAST: ArtifactSet = ArtifactSet {
     name: "在りし日の歌",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "与える治療効果+15%",
+        description: desc!("与える治療効果+15%"),
         buffs: &[StatBuff {
             stat: BuffableStat::HealingBonus,
             value: 0.15,
@@ -1300,12 +1350,14 @@ pub const SONG_OF_DAYS_PAST: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "装備キャラクターがチームメイトを治療した時、治療量を記録する「往日の協奏」効果が発動。6秒後に「往日の協奏」は解消され、その記録した治療量の8%分、チーム全員の通常攻撃、重撃、落下攻撃、元素スキル、元素爆発のダメージをアップ。最大2000まで。「往日の協奏」の持続中に再発動された場合、既存の記録はクリア",
+        description: desc!(
+            "装備キャラクターがチームメイトを治療した時、治療量を記録する「往日の協奏」効果が発動。6秒後に「往日の協奏」は解消され、その記録した治療量の8%分、チーム全員の通常攻撃、重撃、落下攻撃、元素スキル、元素爆発のダメージをアップ。最大2000まで。「往日の協奏」の持続中に再発動された場合、既存の記録はクリア"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "song_days_past_normal",
-                description: "8% of healing as Normal ATK flat DMG, max 2000",
+                description: desc!("8% of healing as Normal ATK flat DMG, max 2000"),
                 stat: BuffableStat::NormalAtkFlatDmg,
                 value: 2000.0,
                 nightsoul_value: None,
@@ -1316,7 +1368,7 @@ pub const SONG_OF_DAYS_PAST: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "song_days_past_charged",
-                description: "8% of healing as Charged ATK flat DMG, max 2000",
+                description: desc!("8% of healing as Charged ATK flat DMG, max 2000"),
                 stat: BuffableStat::ChargedAtkFlatDmg,
                 value: 2000.0,
                 nightsoul_value: None,
@@ -1327,7 +1379,7 @@ pub const SONG_OF_DAYS_PAST: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "song_days_past_plunging",
-                description: "8% of healing as Plunging ATK flat DMG, max 2000",
+                description: desc!("8% of healing as Plunging ATK flat DMG, max 2000"),
                 stat: BuffableStat::PlungingAtkFlatDmg,
                 value: 2000.0,
                 nightsoul_value: None,
@@ -1338,7 +1390,7 @@ pub const SONG_OF_DAYS_PAST: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "song_days_past_skill",
-                description: "8% of healing as Skill flat DMG, max 2000",
+                description: desc!("8% of healing as Skill flat DMG, max 2000"),
                 stat: BuffableStat::SkillFlatDmg,
                 value: 2000.0,
                 nightsoul_value: None,
@@ -1349,7 +1401,7 @@ pub const SONG_OF_DAYS_PAST: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "song_days_past_burst",
-                description: "8% of healing as Burst flat DMG, max 2000",
+                description: desc!("8% of healing as Burst flat DMG, max 2000"),
                 stat: BuffableStat::BurstFlatDmg,
                 value: 2000.0,
                 nightsoul_value: None,
@@ -1367,7 +1419,7 @@ pub const NIGHTTIME_WHISPERS_IN_THE_ECHOING_WOODS: ArtifactSet = ArtifactSet {
     name: "残響の森で囁く夜",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "攻撃力+18%",
+        description: desc!("攻撃力+18%"),
         buffs: &[StatBuff {
             stat: BuffableStat::AtkPercent,
             value: 0.18,
@@ -1376,12 +1428,14 @@ pub const NIGHTTIME_WHISPERS_IN_THE_ECHOING_WOODS: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "元素スキルを使用した後、岩元素ダメージ+20%。夜魂ポイントを消費したとき、岩元素ダメージがさらに+20%、継続時間20秒",
+        description: desc!(
+            "元素スキルを使用した後、岩元素ダメージ+20%。夜魂ポイントを消費したとき、岩元素ダメージがさらに+20%、継続時間20秒"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "nighttime_geo_base",
-                description: "After using Elemental Skill, Geo DMG +20%",
+                description: desc!("After using Elemental Skill, Geo DMG +20%"),
                 stat: BuffableStat::ElementalDmgBonus(Element::Geo),
                 value: 0.20,
                 nightsoul_value: None,
@@ -1392,7 +1446,7 @@ pub const NIGHTTIME_WHISPERS_IN_THE_ECHOING_WOODS: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "nighttime_geo_nightsoul",
-                description: "While consuming Nightsoul points, Geo DMG +20% extra",
+                description: desc!("While consuming Nightsoul points, Geo DMG +20% extra"),
                 stat: BuffableStat::ElementalDmgBonus(Element::Geo),
                 value: 0.20,
                 nightsoul_value: None,
@@ -1413,7 +1467,7 @@ pub const FRAGMENT_OF_HARMONIC_WHIMSY: ArtifactSet = ArtifactSet {
     name: "諧律奇想の断章",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "攻撃力+18%",
+        description: desc!("攻撃力+18%"),
         buffs: &[StatBuff {
             stat: BuffableStat::AtkPercent,
             value: 0.18,
@@ -1422,11 +1476,13 @@ pub const FRAGMENT_OF_HARMONIC_WHIMSY: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "キャラクターのHPが変動した時、与えるダメージ+18%、継続時間6秒、最大3スタック。0.2秒ごとに1回のみ発動可能。待機中でも効果を発動可能",
+        description: desc!(
+            "キャラクターのHPが変動した時、与えるダメージ+18%、継続時間6秒、最大3スタック。0.2秒ごとに1回のみ発動可能。待機中でも効果を発動可能"
+        ),
         buffs: &[],
         conditional_buffs: &[ConditionalBuff {
             name: "harmonic_whimsy_dmg_stacks",
-            description: "HP changes: DMG +18% per stack, max 3",
+            description: desc!("HP changes: DMG +18% per stack, max 3"),
             stat: BuffableStat::DmgBonus,
             value: 0.18,
             nightsoul_value: None,
@@ -1443,7 +1499,7 @@ pub const UNFINISHED_REVERIE: ArtifactSet = ArtifactSet {
     name: "未完の想起",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "攻撃力+18%",
+        description: desc!("攻撃力+18%"),
         buffs: &[StatBuff {
             stat: BuffableStat::AtkPercent,
             value: 0.18,
@@ -1452,11 +1508,13 @@ pub const UNFINISHED_REVERIE: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "燃焼反応または烈開花反応を起こした後、与えるダメージ+50%、継続時間10秒。上記の効果の継続中にフィールド上にいる場合、3秒後に効果が消える",
+        description: desc!(
+            "燃焼反応または烈開花反応を起こした後、与えるダメージ+50%、継続時間10秒。上記の効果の継続中にフィールド上にいる場合、3秒後に効果が消える"
+        ),
         buffs: &[],
         conditional_buffs: &[ConditionalBuff {
             name: "unfinished_reverie_dmg_bonus",
-            description: "After Burning/Burgeon reaction, DMG +50%",
+            description: desc!("After Burning/Burgeon reaction, DMG +50%"),
             stat: BuffableStat::DmgBonus,
             value: 0.50,
             nightsoul_value: None,
@@ -1473,7 +1531,7 @@ pub const SCROLL_OF_THE_HERO_OF_CINDER_CITY: ArtifactSet = ArtifactSet {
     name: "灰燼の都の英雄譚",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "元素熟知+80",
+        description: desc!("元素熟知+80"),
         buffs: &[StatBuff {
             stat: BuffableStat::ElementalMastery,
             value: 80.0,
@@ -1482,12 +1540,14 @@ pub const SCROLL_OF_THE_HERO_OF_CINDER_CITY: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "装備キャラクターが夜魂バースト状態にある、または燃焼、超電導等の元素反応を起こした後、チーム全員の対応する元素ダメージ+12%。同時に最大2種類の元素に効果。待機中でも発動可能。持続時間12秒",
+        description: desc!(
+            "装備キャラクターが夜魂バースト状態にある、または燃焼、超電導等の元素反応を起こした後、チーム全員の対応する元素ダメージ+12%。同時に最大2種類の元素に効果。待機中でも発動可能。持続時間12秒"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "scroll_pyro_dmg",
-                description: "Team Pyro DMG +12%",
+                description: desc!("Team Pyro DMG +12%"),
                 stat: BuffableStat::ElementalDmgBonus(Element::Pyro),
                 value: 0.12,
                 nightsoul_value: Some(0.40),
@@ -1498,7 +1558,7 @@ pub const SCROLL_OF_THE_HERO_OF_CINDER_CITY: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "scroll_hydro_dmg",
-                description: "Team Hydro DMG +12%",
+                description: desc!("Team Hydro DMG +12%"),
                 stat: BuffableStat::ElementalDmgBonus(Element::Hydro),
                 value: 0.12,
                 nightsoul_value: Some(0.40),
@@ -1509,7 +1569,7 @@ pub const SCROLL_OF_THE_HERO_OF_CINDER_CITY: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "scroll_electro_dmg",
-                description: "Team Electro DMG +12%",
+                description: desc!("Team Electro DMG +12%"),
                 stat: BuffableStat::ElementalDmgBonus(Element::Electro),
                 value: 0.12,
                 nightsoul_value: Some(0.40),
@@ -1520,7 +1580,7 @@ pub const SCROLL_OF_THE_HERO_OF_CINDER_CITY: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "scroll_cryo_dmg",
-                description: "Team Cryo DMG +12%",
+                description: desc!("Team Cryo DMG +12%"),
                 stat: BuffableStat::ElementalDmgBonus(Element::Cryo),
                 value: 0.12,
                 nightsoul_value: Some(0.40),
@@ -1531,7 +1591,7 @@ pub const SCROLL_OF_THE_HERO_OF_CINDER_CITY: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "scroll_anemo_dmg",
-                description: "Team Anemo DMG +12%",
+                description: desc!("Team Anemo DMG +12%"),
                 stat: BuffableStat::ElementalDmgBonus(Element::Anemo),
                 value: 0.12,
                 nightsoul_value: Some(0.40),
@@ -1542,7 +1602,7 @@ pub const SCROLL_OF_THE_HERO_OF_CINDER_CITY: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "scroll_geo_dmg",
-                description: "Team Geo DMG +12%",
+                description: desc!("Team Geo DMG +12%"),
                 stat: BuffableStat::ElementalDmgBonus(Element::Geo),
                 value: 0.12,
                 nightsoul_value: Some(0.40),
@@ -1553,7 +1613,7 @@ pub const SCROLL_OF_THE_HERO_OF_CINDER_CITY: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "scroll_dendro_dmg",
-                description: "Team Dendro DMG +12%",
+                description: desc!("Team Dendro DMG +12%"),
                 stat: BuffableStat::ElementalDmgBonus(Element::Dendro),
                 value: 0.12,
                 nightsoul_value: Some(0.40),
@@ -1571,11 +1631,13 @@ pub const OBSIDIAN_CODEX: ArtifactSet = ArtifactSet {
     name: "黒曜の秘典",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "夜魂の加護状態にあり、かつフィールド上にいるキャラクターの与えるダメージ+15%",
+        description: desc!(
+            "夜魂の加護状態にあり、かつフィールド上にいるキャラクターの与えるダメージ+15%"
+        ),
         buffs: &[],
         conditional_buffs: &[ConditionalBuff {
             name: "Obsidian Codex Nightsoul DMG Bonus",
-            description: "While in Nightsoul's Blessing and on field, DMG +15%",
+            description: desc!("While in Nightsoul's Blessing and on field, DMG +15%"),
             stat: BuffableStat::DmgBonus,
             value: 0.15,
             nightsoul_value: None,
@@ -1586,11 +1648,13 @@ pub const OBSIDIAN_CODEX: ArtifactSet = ArtifactSet {
         }],
     },
     four_piece: SetEffect {
-        description: "夜魂の加護状態にあるキャラクターのナイトソウルポイントが上限の50%以下の場合、会心率+40%",
+        description: desc!(
+            "夜魂の加護状態にあるキャラクターのナイトソウルポイントが上限の50%以下の場合、会心率+40%"
+        ),
         buffs: &[],
         conditional_buffs: &[ConditionalBuff {
             name: "Obsidian Codex Crit Rate Bonus",
-            description: "When Nightsoul points below 50%, Crit Rate +40%",
+            description: desc!("When Nightsoul points below 50%, Crit Rate +40%"),
             stat: BuffableStat::CritRate,
             value: 0.40,
             nightsoul_value: None,
@@ -1607,7 +1671,7 @@ pub const RESOLUTION_OF_SOJOURNER: ArtifactSet = ArtifactSet {
     name: "旅人の心",
     rarity: ArtifactRarity::Star4And5,
     two_piece: SetEffect {
-        description: "攻撃力+18%",
+        description: desc!("攻撃力+18%"),
         buffs: &[StatBuff {
             stat: BuffableStat::AtkPercent,
             value: 0.18,
@@ -1616,11 +1680,11 @@ pub const RESOLUTION_OF_SOJOURNER: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "重撃の会心率+30%",
+        description: desc!("重撃の会心率+30%"),
         buffs: &[],
         conditional_buffs: &[ConditionalBuff {
             name: "sojourner_charged_crit",
-            description: "Charged Attack Crit Rate +30%",
+            description: desc!("Charged Attack Crit Rate +30%"),
             stat: BuffableStat::CritRate,
             value: 0.30,
             nightsoul_value: None,
@@ -1637,7 +1701,7 @@ pub const TINY_MIRACLE: ArtifactSet = ArtifactSet {
     name: "奇跡",
     rarity: ArtifactRarity::Star4And5,
     two_piece: SetEffect {
-        description: "全元素耐性+20%",
+        description: desc!("全元素耐性+20%"),
         buffs: &[
             StatBuff {
                 stat: BuffableStat::ElementalRes(Element::Pyro),
@@ -1678,12 +1742,14 @@ pub const TINY_MIRACLE: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "元素ダメージを受けた後、その元素の耐性+30%、継続時間10秒。10秒ごとに1回のみ発動可能",
+        description: desc!(
+            "元素ダメージを受けた後、その元素の耐性+30%、継続時間10秒。10秒ごとに1回のみ発動可能"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "tiny_miracle_pyro_res",
-                description: "After taking Pyro DMG: Pyro RES +30%",
+                description: desc!("After taking Pyro DMG: Pyro RES +30%"),
                 stat: BuffableStat::ElementalRes(Element::Pyro),
                 value: 0.30,
                 nightsoul_value: None,
@@ -1694,7 +1760,7 @@ pub const TINY_MIRACLE: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "tiny_miracle_hydro_res",
-                description: "After taking Hydro DMG: Hydro RES +30%",
+                description: desc!("After taking Hydro DMG: Hydro RES +30%"),
                 stat: BuffableStat::ElementalRes(Element::Hydro),
                 value: 0.30,
                 nightsoul_value: None,
@@ -1705,7 +1771,7 @@ pub const TINY_MIRACLE: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "tiny_miracle_electro_res",
-                description: "After taking Electro DMG: Electro RES +30%",
+                description: desc!("After taking Electro DMG: Electro RES +30%"),
                 stat: BuffableStat::ElementalRes(Element::Electro),
                 value: 0.30,
                 nightsoul_value: None,
@@ -1716,7 +1782,7 @@ pub const TINY_MIRACLE: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "tiny_miracle_cryo_res",
-                description: "After taking Cryo DMG: Cryo RES +30%",
+                description: desc!("After taking Cryo DMG: Cryo RES +30%"),
                 stat: BuffableStat::ElementalRes(Element::Cryo),
                 value: 0.30,
                 nightsoul_value: None,
@@ -1727,7 +1793,7 @@ pub const TINY_MIRACLE: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "tiny_miracle_dendro_res",
-                description: "After taking Dendro DMG: Dendro RES +30%",
+                description: desc!("After taking Dendro DMG: Dendro RES +30%"),
                 stat: BuffableStat::ElementalRes(Element::Dendro),
                 value: 0.30,
                 nightsoul_value: None,
@@ -1738,7 +1804,7 @@ pub const TINY_MIRACLE: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "tiny_miracle_anemo_res",
-                description: "After taking Anemo DMG: Anemo RES +30%",
+                description: desc!("After taking Anemo DMG: Anemo RES +30%"),
                 stat: BuffableStat::ElementalRes(Element::Anemo),
                 value: 0.30,
                 nightsoul_value: None,
@@ -1749,7 +1815,7 @@ pub const TINY_MIRACLE: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "tiny_miracle_geo_res",
-                description: "After taking Geo DMG: Geo RES +30%",
+                description: desc!("After taking Geo DMG: Geo RES +30%"),
                 stat: BuffableStat::ElementalRes(Element::Geo),
                 value: 0.30,
                 nightsoul_value: None,
@@ -1767,7 +1833,7 @@ pub const BERSERKER: ArtifactSet = ArtifactSet {
     name: "狂戦士",
     rarity: ArtifactRarity::Star4,
     two_piece: SetEffect {
-        description: "会心率+12%",
+        description: desc!("会心率+12%"),
         buffs: &[StatBuff {
             stat: BuffableStat::CritRate,
             value: 0.12,
@@ -1776,11 +1842,11 @@ pub const BERSERKER: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "HPが70%以下になると、会心率+24%",
+        description: desc!("HPが70%以下になると、会心率+24%"),
         buffs: &[],
         conditional_buffs: &[ConditionalBuff {
             name: "berserker_low_hp_crit",
-            description: "When HP below 70%, Crit Rate +24%",
+            description: desc!("When HP below 70%, Crit Rate +24%"),
             stat: BuffableStat::CritRate,
             value: 0.24,
             nightsoul_value: None,
@@ -1797,7 +1863,7 @@ pub const INSTRUCTOR: ArtifactSet = ArtifactSet {
     name: "教官",
     rarity: ArtifactRarity::Star4,
     two_piece: SetEffect {
-        description: "元素熟知+80",
+        description: desc!("元素熟知+80"),
         buffs: &[StatBuff {
             stat: BuffableStat::ElementalMastery,
             value: 80.0,
@@ -1806,11 +1872,11 @@ pub const INSTRUCTOR: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "元素反応を起こした後、チーム全員の元素熟知+120、継続時間8秒",
+        description: desc!("元素反応を起こした後、チーム全員の元素熟知+120、継続時間8秒"),
         buffs: &[],
         conditional_buffs: &[ConditionalBuff {
             name: "instructor_em_bonus",
-            description: "After triggering reaction, team EM +120",
+            description: desc!("After triggering reaction, team EM +120"),
             stat: BuffableStat::ElementalMastery,
             value: 120.0,
             nightsoul_value: None,
@@ -1827,7 +1893,7 @@ pub const EXILE: ArtifactSet = ArtifactSet {
     name: "亡命者",
     rarity: ArtifactRarity::Star4,
     two_piece: SetEffect {
-        description: "元素チャージ効率+20%",
+        description: desc!("元素チャージ効率+20%"),
         buffs: &[StatBuff {
             stat: BuffableStat::EnergyRecharge,
             value: 0.20,
@@ -1836,7 +1902,9 @@ pub const EXILE: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "元素爆発を発動すると、2秒ごとにチームメイト全員の元素エネルギーを2回復、継続時間6秒。重ねがけ不可",
+        description: desc!(
+            "元素爆発を発動すると、2秒ごとにチームメイト全員の元素エネルギーを2回復、継続時間6秒。重ねがけ不可"
+        ),
         buffs: &[],
         conditional_buffs: &[],
     },
@@ -1847,7 +1915,7 @@ pub const MARTIAL_ARTIST: ArtifactSet = ArtifactSet {
     name: "武人",
     rarity: ArtifactRarity::Star4,
     two_piece: SetEffect {
-        description: "通常攻撃と重撃ダメージ+15%",
+        description: desc!("通常攻撃と重撃ダメージ+15%"),
         buffs: &[
             StatBuff {
                 stat: BuffableStat::NormalAtkDmgBonus,
@@ -1863,12 +1931,14 @@ pub const MARTIAL_ARTIST: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "元素スキルまたは元素爆発を発動した後、通常攻撃と重撃のダメージ+25%、継続時間8秒",
+        description: desc!(
+            "元素スキルまたは元素爆発を発動した後、通常攻撃と重撃のダメージ+25%、継続時間8秒"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "martial_artist_normal_bonus",
-                description: "After Skill/Burst use, Normal Attack DMG +25%",
+                description: desc!("After Skill/Burst use, Normal Attack DMG +25%"),
                 stat: BuffableStat::NormalAtkDmgBonus,
                 value: 0.25,
                 nightsoul_value: None,
@@ -1879,7 +1949,7 @@ pub const MARTIAL_ARTIST: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "martial_artist_charged_bonus",
-                description: "After Skill/Burst use, Charged Attack DMG +25%",
+                description: desc!("After Skill/Burst use, Charged Attack DMG +25%"),
                 stat: BuffableStat::ChargedAtkDmgBonus,
                 value: 0.25,
                 nightsoul_value: None,
@@ -1897,7 +1967,7 @@ pub const DEFENDERS_WILL: ArtifactSet = ArtifactSet {
     name: "守護の心",
     rarity: ArtifactRarity::Star4,
     two_piece: SetEffect {
-        description: "防御力+30%",
+        description: desc!("防御力+30%"),
         buffs: &[StatBuff {
             stat: BuffableStat::DefPercent,
             value: 0.30,
@@ -1906,12 +1976,12 @@ pub const DEFENDERS_WILL: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "チーム内キャラクターの元素タイプ1種類につき、対応する元素耐性+30%",
+        description: desc!("チーム内キャラクターの元素タイプ1種類につき、対応する元素耐性+30%"),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "defenders_will_pyro_res",
-                description: "Pyro character on team: Pyro RES +30%",
+                description: desc!("Pyro character on team: Pyro RES +30%"),
                 stat: BuffableStat::ElementalRes(Element::Pyro),
                 value: 0.30,
                 nightsoul_value: None,
@@ -1925,7 +1995,7 @@ pub const DEFENDERS_WILL: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "defenders_will_hydro_res",
-                description: "Hydro character on team: Hydro RES +30%",
+                description: desc!("Hydro character on team: Hydro RES +30%"),
                 stat: BuffableStat::ElementalRes(Element::Hydro),
                 value: 0.30,
                 nightsoul_value: None,
@@ -1939,7 +2009,7 @@ pub const DEFENDERS_WILL: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "defenders_will_electro_res",
-                description: "Electro character on team: Electro RES +30%",
+                description: desc!("Electro character on team: Electro RES +30%"),
                 stat: BuffableStat::ElementalRes(Element::Electro),
                 value: 0.30,
                 nightsoul_value: None,
@@ -1953,7 +2023,7 @@ pub const DEFENDERS_WILL: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "defenders_will_cryo_res",
-                description: "Cryo character on team: Cryo RES +30%",
+                description: desc!("Cryo character on team: Cryo RES +30%"),
                 stat: BuffableStat::ElementalRes(Element::Cryo),
                 value: 0.30,
                 nightsoul_value: None,
@@ -1967,7 +2037,7 @@ pub const DEFENDERS_WILL: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "defenders_will_dendro_res",
-                description: "Dendro character on team: Dendro RES +30%",
+                description: desc!("Dendro character on team: Dendro RES +30%"),
                 stat: BuffableStat::ElementalRes(Element::Dendro),
                 value: 0.30,
                 nightsoul_value: None,
@@ -1981,7 +2051,7 @@ pub const DEFENDERS_WILL: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "defenders_will_anemo_res",
-                description: "Anemo character on team: Anemo RES +30%",
+                description: desc!("Anemo character on team: Anemo RES +30%"),
                 stat: BuffableStat::ElementalRes(Element::Anemo),
                 value: 0.30,
                 nightsoul_value: None,
@@ -1995,7 +2065,7 @@ pub const DEFENDERS_WILL: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "defenders_will_geo_res",
-                description: "Geo character on team: Geo RES +30%",
+                description: desc!("Geo character on team: Geo RES +30%"),
                 stat: BuffableStat::ElementalRes(Element::Geo),
                 value: 0.30,
                 nightsoul_value: None,
@@ -2016,7 +2086,7 @@ pub const BRAVE_HEART: ArtifactSet = ArtifactSet {
     name: "勇士の心",
     rarity: ArtifactRarity::Star4,
     two_piece: SetEffect {
-        description: "攻撃力+18%",
+        description: desc!("攻撃力+18%"),
         buffs: &[StatBuff {
             stat: BuffableStat::AtkPercent,
             value: 0.18,
@@ -2025,11 +2095,11 @@ pub const BRAVE_HEART: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "HPが50%以上の敵に対するダメージ+30%",
+        description: desc!("HPが50%以上の敵に対するダメージ+30%"),
         buffs: &[],
         conditional_buffs: &[ConditionalBuff {
             name: "brave_heart_dmg_bonus",
-            description: "DMG +30% vs enemies with HP above 50%",
+            description: desc!("DMG +30% vs enemies with HP above 50%"),
             stat: BuffableStat::DmgBonus,
             value: 0.30,
             nightsoul_value: None,
@@ -2046,7 +2116,7 @@ pub const GAMBLER: ArtifactSet = ArtifactSet {
     name: "博徒",
     rarity: ArtifactRarity::Star4,
     two_piece: SetEffect {
-        description: "元素スキルのダメージ+20%",
+        description: desc!("元素スキルのダメージ+20%"),
         buffs: &[StatBuff {
             stat: BuffableStat::SkillDmgBonus,
             value: 0.20,
@@ -2055,7 +2125,9 @@ pub const GAMBLER: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "敵を倒した時、100%の確率で元素スキルのクールタイムをリセットする。15秒ごとに1回のみ発動可能",
+        description: desc!(
+            "敵を倒した時、100%の確率で元素スキルのクールタイムをリセットする。15秒ごとに1回のみ発動可能"
+        ),
         buffs: &[],
         conditional_buffs: &[],
     },
@@ -2066,7 +2138,7 @@ pub const SCHOLAR: ArtifactSet = ArtifactSet {
     name: "学者",
     rarity: ArtifactRarity::Star4,
     two_piece: SetEffect {
-        description: "元素チャージ効率+20%",
+        description: desc!("元素チャージ効率+20%"),
         buffs: &[StatBuff {
             stat: BuffableStat::EnergyRecharge,
             value: 0.20,
@@ -2075,7 +2147,9 @@ pub const SCHOLAR: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "元素エネルギーを獲得した時、チーム全員の弓、法器キャラの元素エネルギーを3回復。3秒ごとに1回のみ発動可能",
+        description: desc!(
+            "元素エネルギーを獲得した時、チーム全員の弓、法器キャラの元素エネルギーを3回復。3秒ごとに1回のみ発動可能"
+        ),
         buffs: &[],
         conditional_buffs: &[],
     },
@@ -2086,12 +2160,12 @@ pub const PRAYERS_FOR_ILLUMINATION: ArtifactSet = ArtifactSet {
     name: "火祭りの人",
     rarity: ArtifactRarity::Star4,
     two_piece: SetEffect {
-        description: "炎元素に影響されている時間-40%",
+        description: desc!("炎元素に影響されている時間-40%"),
         buffs: &[],
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "",
+        description: desc!(""),
         buffs: &[],
         conditional_buffs: &[],
     },
@@ -2102,12 +2176,12 @@ pub const PRAYERS_FOR_DESTINY: ArtifactSet = ArtifactSet {
     name: "水祭りの人",
     rarity: ArtifactRarity::Star4,
     two_piece: SetEffect {
-        description: "水元素に影響されている時間-40%",
+        description: desc!("水元素に影響されている時間-40%"),
         buffs: &[],
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "",
+        description: desc!(""),
         buffs: &[],
         conditional_buffs: &[],
     },
@@ -2118,12 +2192,12 @@ pub const PRAYERS_FOR_WISDOM: ArtifactSet = ArtifactSet {
     name: "雷祭りの人",
     rarity: ArtifactRarity::Star4,
     two_piece: SetEffect {
-        description: "雷元素に影響されている時間-40%",
+        description: desc!("雷元素に影響されている時間-40%"),
         buffs: &[],
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "",
+        description: desc!(""),
         buffs: &[],
         conditional_buffs: &[],
     },
@@ -2134,12 +2208,12 @@ pub const PRAYERS_TO_SPRINGTIME: ArtifactSet = ArtifactSet {
     name: "氷祭りの人",
     rarity: ArtifactRarity::Star4,
     two_piece: SetEffect {
-        description: "氷元素に影響されている時間-40%",
+        description: desc!("氷元素に影響されている時間-40%"),
         buffs: &[],
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "",
+        description: desc!(""),
         buffs: &[],
         conditional_buffs: &[],
     },
@@ -2154,7 +2228,7 @@ pub const GLORY_OF_THE_ANCIENT_SEA: ArtifactSet = ArtifactSet {
     name: "古海の栄光",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "HP+20%",
+        description: desc!("HP+20%"),
         buffs: &[StatBuff {
             stat: BuffableStat::HpPercent,
             value: 0.20,
@@ -2163,13 +2237,15 @@ pub const GLORY_OF_THE_ANCIENT_SEA: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "現在のHP上限と上限を超えた治療量に基づき通常攻撃と重撃のダメージがアップ。HP上限が30000を超えた場合、超過量1000ごとに通常攻撃と重撃のダメージが+24。超過回復量1000ごとに通常攻撃と重撃のダメージがさらに+32。超過回復効果のスタックは最大6スタック。持続時間6秒",
+        description: desc!(
+            "現在のHP上限と上限を超えた治療量に基づき通常攻撃と重撃のダメージがアップ。HP上限が30000を超えた場合、超過量1000ごとに通常攻撃と重撃のダメージが+24。超過回復量1000ごとに通常攻撃と重撃のダメージがさらに+32。超過回復効果のスタックは最大6スタック。持続時間6秒"
+        ),
         buffs: &[],
         conditional_buffs: &[
             // HP excess: (total_HP - 30000) * 0.024 = +24 per 1000 HP over 30000
             ConditionalBuff {
                 name: "glory_ancient_sea_hp_normal",
-                description: "Per 1000 HP over 30000: Normal ATK flat DMG +24",
+                description: desc!("Per 1000 HP over 30000: Normal ATK flat DMG +24"),
                 stat: BuffableStat::NormalAtkFlatDmg,
                 value: 0.024,
                 nightsoul_value: None,
@@ -2184,7 +2260,7 @@ pub const GLORY_OF_THE_ANCIENT_SEA: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "glory_ancient_sea_hp_charged",
-                description: "Per 1000 HP over 30000: Charged ATK flat DMG +24",
+                description: desc!("Per 1000 HP over 30000: Charged ATK flat DMG +24"),
                 stat: BuffableStat::ChargedAtkFlatDmg,
                 value: 0.024,
                 nightsoul_value: None,
@@ -2200,7 +2276,7 @@ pub const GLORY_OF_THE_ANCIENT_SEA: ArtifactSet = ArtifactSet {
             // Excess healing stacks: +32 per stack, max 6
             ConditionalBuff {
                 name: "glory_ancient_sea_heal_normal",
-                description: "Excess healing stacks: Normal ATK flat DMG +32/stack, max 6",
+                description: desc!("Excess healing stacks: Normal ATK flat DMG +32/stack, max 6"),
                 stat: BuffableStat::NormalAtkFlatDmg,
                 value: 32.0,
                 nightsoul_value: None,
@@ -2211,7 +2287,7 @@ pub const GLORY_OF_THE_ANCIENT_SEA: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "glory_ancient_sea_heal_charged",
-                description: "Excess healing stacks: Charged ATK flat DMG +32/stack, max 6",
+                description: desc!("Excess healing stacks: Charged ATK flat DMG +32/stack, max 6"),
                 stat: BuffableStat::ChargedAtkFlatDmg,
                 value: 32.0,
                 nightsoul_value: None,
@@ -2229,7 +2305,7 @@ pub const CHRONICLED_SANDS_AND_WATER: ArtifactSet = ArtifactSet {
     name: "記憶の砂と水",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "元素チャージ効率+20%",
+        description: desc!("元素チャージ効率+20%"),
         buffs: &[StatBuff {
             stat: BuffableStat::EnergyRecharge,
             value: 0.20,
@@ -2238,12 +2314,14 @@ pub const CHRONICLED_SANDS_AND_WATER: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "元素チャージ効率の40%に基づいて、元素スキルと元素爆発のダメージアップ。この方式でアップできるダメージは最大80%まで",
+        description: desc!(
+            "元素チャージ効率の40%に基づいて、元素スキルと元素爆発のダメージアップ。この方式でアップできるダメージは最大80%まで"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "chronicled_skill_bonus",
-                description: "Skill DMG: 40% of ER, max 80%",
+                description: desc!("Skill DMG: 40% of ER, max 80%"),
                 stat: BuffableStat::SkillDmgBonus,
                 value: 0.40,
                 nightsoul_value: None,
@@ -2258,7 +2336,7 @@ pub const CHRONICLED_SANDS_AND_WATER: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "chronicled_burst_bonus",
-                description: "Burst DMG: 40% of ER, max 80%",
+                description: desc!("Burst DMG: 40% of ER, max 80%"),
                 stat: BuffableStat::BurstDmgBonus,
                 value: 0.40,
                 nightsoul_value: None,
@@ -2282,7 +2360,7 @@ pub const NIGHT_OF_THE_SKYS_UNVEILING: ArtifactSet = ArtifactSet {
     name: "天幕の夜の露見",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "元素熟知+80",
+        description: desc!("元素熟知+80"),
         buffs: &[StatBuff {
             stat: BuffableStat::ElementalMastery,
             value: 80.0,
@@ -2291,12 +2369,16 @@ pub const NIGHT_OF_THE_SKYS_UNVEILING: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "近くのチームメンバーが月反応を起こした時、装備キャラがフィールド上にいると「月明かり：意志」効果を4秒間獲得：月兆が新月の光/昇天の光の時、会心率+15%/30%。チーム全員の月反応ダメージが、チームメンバーが持つ異なる月明かり効果1つにつき10%アップ",
+        description: desc!(
+            "近くのチームメンバーが月反応を起こした時、装備キャラがフィールド上にいると「月明かり：意志」効果を4秒間獲得：月兆が新月の光/昇天の光の時、会心率+15%/30%。チーム全員の月反応ダメージが、チームメンバーが持つ異なる月明かり効果1つにつき10%アップ"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "gleaming_moon_intent_crit",
-                description: "Gleaming Moon: Intent — CRIT Rate +15%/30% (Nascent/Ascendant Gleam)",
+                description: desc!(
+                    "Gleaming Moon: Intent — CRIT Rate +15%/30% (Nascent/Ascendant Gleam)"
+                ),
                 stat: BuffableStat::CritRate,
                 value: 0.15,
                 nightsoul_value: None,
@@ -2307,7 +2389,7 @@ pub const NIGHT_OF_THE_SKYS_UNVEILING: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "gleaming_moon_intent_lunar_dmg",
-                description: "Gleaming Moon: Intent — Lunar Reaction DMG +10%",
+                description: desc!("Gleaming Moon: Intent — Lunar Reaction DMG +10%"),
                 stat: BuffableStat::TransformativeBonus,
                 value: 0.10,
                 nightsoul_value: None,
@@ -2325,7 +2407,7 @@ pub const SILKEN_MOONS_SERENADE: ArtifactSet = ArtifactSet {
     name: "絹月の小夜曲",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "元素チャージ効率+20%",
+        description: desc!("元素チャージ効率+20%"),
         buffs: &[StatBuff {
             stat: BuffableStat::EnergyRecharge,
             value: 0.20,
@@ -2334,12 +2416,16 @@ pub const SILKEN_MOONS_SERENADE: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "元素ダメージを与えた時、「月明かり：献身」効果を8秒間獲得：月兆が新月の光/昇天の光の時、チーム全員の元素熟知+60/120。装備キャラがフィールド外でも発動可。チーム全員の月反応ダメージが、チームメンバーが持つ異なる月明かり効果1つにつき10%アップ",
+        description: desc!(
+            "元素ダメージを与えた時、「月明かり：献身」効果を8秒間獲得：月兆が新月の光/昇天の光の時、チーム全員の元素熟知+60/120。装備キャラがフィールド外でも発動可。チーム全員の月反応ダメージが、チームメンバーが持つ異なる月明かり効果1つにつき10%アップ"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "gleaming_moon_devotion_em",
-                description: "Gleaming Moon: Devotion — EM +60/120 (Nascent/Ascendant Gleam)",
+                description: desc!(
+                    "Gleaming Moon: Devotion — EM +60/120 (Nascent/Ascendant Gleam)"
+                ),
                 stat: BuffableStat::ElementalMastery,
                 value: 60.0,
                 nightsoul_value: None,
@@ -2350,7 +2436,7 @@ pub const SILKEN_MOONS_SERENADE: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "gleaming_moon_devotion_lunar_dmg",
-                description: "Gleaming Moon: Devotion — Lunar Reaction DMG +10%",
+                description: desc!("Gleaming Moon: Devotion — Lunar Reaction DMG +10%"),
                 stat: BuffableStat::TransformativeBonus,
                 value: 0.10,
                 nightsoul_value: None,
@@ -2370,7 +2456,7 @@ pub const AUBADE_OF_MORNINGSTAR_AND_MOON: ArtifactSet = ArtifactSet {
     name: "明星と月のオーバード",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "元素熟知+80",
+        description: desc!("元素熟知+80"),
         buffs: &[StatBuff {
             stat: BuffableStat::ElementalMastery,
             value: 80.0,
@@ -2379,12 +2465,14 @@ pub const AUBADE_OF_MORNINGSTAR_AND_MOON: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "装備キャラがフィールド外の時、月反応ダメージ+20%。月兆レベルが昇天の光以上の場合、月反応ダメージがさらに+40%。装備キャラがフィールドに復帰して3秒後に効果消滅",
+        description: desc!(
+            "装備キャラがフィールド外の時、月反応ダメージ+20%。月兆レベルが昇天の光以上の場合、月反応ダメージがさらに+40%。装備キャラがフィールドに復帰して3秒後に効果消滅"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "aubade_off_field_lunar",
-                description: "Off-field Lunar Reaction DMG +20%",
+                description: desc!("Off-field Lunar Reaction DMG +20%"),
                 stat: BuffableStat::TransformativeBonus,
                 value: 0.20,
                 nightsoul_value: None,
@@ -2395,7 +2483,7 @@ pub const AUBADE_OF_MORNINGSTAR_AND_MOON: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "aubade_ascendant_lunar",
-                description: "Ascendant Gleam: additional Lunar Reaction DMG +40%",
+                description: desc!("Ascendant Gleam: additional Lunar Reaction DMG +40%"),
                 stat: BuffableStat::TransformativeBonus,
                 value: 0.40,
                 nightsoul_value: None,
@@ -2413,7 +2501,7 @@ pub const A_DAY_CARVED_FROM_RISING_WINDS: ArtifactSet = ArtifactSet {
     name: "昇風に刻まれた一日",
     rarity: ArtifactRarity::Star5,
     two_piece: SetEffect {
-        description: "攻撃力+18%",
+        description: desc!("攻撃力+18%"),
         buffs: &[StatBuff {
             stat: BuffableStat::AtkPercent,
             value: 0.18,
@@ -2422,12 +2510,14 @@ pub const A_DAY_CARVED_FROM_RISING_WINDS: ArtifactSet = ArtifactSet {
         conditional_buffs: &[],
     },
     four_piece: SetEffect {
-        description: "通常攻撃、重撃、元素スキルまたは元素爆発が敵に命中後、「牧風の祝福」効果を6秒間獲得：攻撃力+25%。装備キャラが「魔女の宿題」を完了している場合、「牧風の決意」に昇格し、会心率がさらに+20%。フィールド外でも発動可",
+        description: desc!(
+            "通常攻撃、重撃、元素スキルまたは元素爆発が敵に命中後、「牧風の祝福」効果を6秒間獲得：攻撃力+25%。装備キャラが「魔女の宿題」を完了している場合、「牧風の決意」に昇格し、会心率がさらに+20%。フィールド外でも発動可"
+        ),
         buffs: &[],
         conditional_buffs: &[
             ConditionalBuff {
                 name: "blessing_of_pastoral_winds_atk",
-                description: "Blessing of Pastoral Winds: ATK +25%",
+                description: desc!("Blessing of Pastoral Winds: ATK +25%"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.25,
                 nightsoul_value: None,
@@ -2438,7 +2528,7 @@ pub const A_DAY_CARVED_FROM_RISING_WINDS: ArtifactSet = ArtifactSet {
             },
             ConditionalBuff {
                 name: "resolve_of_pastoral_winds_crit",
-                description: "Resolve of Pastoral Winds (Witch's Homework): CRIT Rate +20%",
+                description: desc!("Resolve of Pastoral Winds (Witch's Homework): CRIT Rate +20%"),
                 stat: BuffableStat::CritRate,
                 value: 0.20,
                 nightsoul_value: None,

--- a/crates/data/src/lib.rs
+++ b/crates/data/src/lib.rs
@@ -8,6 +8,12 @@
 //! - 52 artifact sets
 //! - 15 enemies with resistance templates
 //!
+//! ## Features
+//!
+//! - `descriptions` (default): Include human-readable description strings for
+//!   weapon passives, artifact set effects, and talent buffs. Disable to reduce
+//!   binary size (saves ~100-150 KB in WASM builds).
+//!
 //! ## Example
 //!
 //! ```
@@ -21,6 +27,23 @@
 //! ```
 
 #![deny(missing_docs)]
+
+/// Returns the description string when the `descriptions` feature is enabled,
+/// or an empty string when disabled (to reduce binary size).
+#[cfg(feature = "descriptions")]
+macro_rules! desc {
+    ($s:expr) => {
+        $s
+    };
+}
+
+/// Returns an empty string when the `descriptions` feature is disabled.
+#[cfg(not(feature = "descriptions"))]
+macro_rules! desc {
+    ($s:expr) => {
+        ""
+    };
+}
 
 #[allow(missing_docs)]
 pub mod artifact_stats;

--- a/crates/data/src/moonsign_chars.rs
+++ b/crates/data/src/moonsign_chars.rs
@@ -108,7 +108,7 @@ pub const ALL_MOONSIGN_BENEDICTIONS: &[MoonsignBenedictionDef] = &[
 pub const LAUMA_TALENT_ENHANCEMENTS: &[MoonsignTalentEnhancement] = &[MoonsignTalentEnhancement {
     character_name: "Lauma",
     required_level: MoonsignLevel::NascentGleam,
-    description: "Bloom gains crit at Nascent Gleam",
+    description: desc!("Bloom gains crit at Nascent Gleam"),
     effect: MoonsignTalentEffect::GrantReactionCrit {
         reaction: Reaction::LunarBloom,
         crit_rate: 0.15,
@@ -120,7 +120,7 @@ pub const LAUMA_TALENT_ENHANCEMENTS: &[MoonsignTalentEnhancement] = &[MoonsignTa
 pub const FLINS_TALENT_ENHANCEMENTS: &[MoonsignTalentEnhancement] = &[MoonsignTalentEnhancement {
     character_name: "Flins",
     required_level: MoonsignLevel::AscendantGleam,
-    description: "Lunar-Charged DMG +20% at Ascendant Gleam",
+    description: desc!("Lunar-Charged DMG +20% at Ascendant Gleam"),
     effect: MoonsignTalentEffect::ReactionDmgBonus {
         reaction: Reaction::LunarElectroCharged,
         bonus: 0.20,
@@ -131,7 +131,9 @@ pub const FLINS_TALENT_ENHANCEMENTS: &[MoonsignTalentEnhancement] = &[MoonsignTa
 pub const NEFER_TALENT_ENHANCEMENTS: &[MoonsignTalentEnhancement] = &[MoonsignTalentEnhancement {
     character_name: "Nefer",
     required_level: MoonsignLevel::AscendantGleam,
-    description: "At Ascendant Gleam, absorbing Seeds of Deceit grants Veil of Falsehood stacks (max 3). At 3 stacks, EM +100 for 8s",
+    description: desc!(
+        "At Ascendant Gleam, absorbing Seeds of Deceit grants Veil of Falsehood stacks (max 3). At 3 stacks, EM +100 for 8s"
+    ),
     effect: MoonsignTalentEffect::StatBuff {
         stat: BuffableStat::ElementalMastery,
         value: 100.0,
@@ -145,7 +147,7 @@ pub const AINO_TALENT_ENHANCEMENTS: &[MoonsignTalentEnhancement] = &[
     MoonsignTalentEnhancement {
         character_name: "Aino",
         required_level: MoonsignLevel::NascentGleam,
-        description: "C6: At Nascent Gleam+, reaction DMG +15% for 15s after Burst",
+        description: desc!("C6: At Nascent Gleam+, reaction DMG +15% for 15s after Burst"),
         effect: MoonsignTalentEffect::StatBuff {
             stat: BuffableStat::TransformativeBonus,
             value: 0.15,
@@ -155,7 +157,9 @@ pub const AINO_TALENT_ENHANCEMENTS: &[MoonsignTalentEnhancement] = &[
     MoonsignTalentEnhancement {
         character_name: "Aino",
         required_level: MoonsignLevel::AscendantGleam,
-        description: "C6: At Ascendant Gleam, reaction DMG bonus increases by +20% (total +35%)",
+        description: desc!(
+            "C6: At Ascendant Gleam, reaction DMG bonus increases by +20% (total +35%)"
+        ),
         effect: MoonsignTalentEffect::ReactionDmgBonus {
             reaction: Reaction::LunarElectroCharged,
             bonus: 0.20,

--- a/crates/data/src/talent_buffs/anemo.rs
+++ b/crates/data/src/talent_buffs/anemo.rs
@@ -11,7 +11,7 @@ static FARUZAN_BURST_ANEMO_SCALING: [f64; 15] = [
 static FARUZAN_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Prayerful Wind's Benefit",
-        description: "Anemo DMG Bonus based on burst talent level",
+        description: desc!("Anemo DMG Bonus based on burst talent level"),
         stat: BuffableStat::ElementalDmgBonus(Element::Anemo),
         base_value: 0.0,
         scales_with_talent: true,
@@ -25,7 +25,7 @@ static FARUZAN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Perfidious Wind's Bale",
-        description: "A4: Enemies hit by Pressurized Collapse have Anemo RES -30%",
+        description: desc!("A4: Enemies hit by Pressurized Collapse have Anemo RES -30%"),
         stat: BuffableStat::ElementalResReduction(Element::Anemo),
         base_value: 0.30,
         scales_with_talent: false,
@@ -39,7 +39,7 @@ static FARUZAN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "faruzan_c6_anemo_crit_dmg",
-        description: "C6: Anemo DMG CRIT DMG +40%",
+        description: desc!("C6: Anemo DMG CRIT DMG +40%"),
         stat: BuffableStat::CritDmg,
         base_value: 0.40,
         scales_with_talent: false,
@@ -58,7 +58,7 @@ static FARUZAN_BUFFS: &[TalentBuffDef] = &[
 static JAHODA_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Jahoda A4 EM Buff",
-        description: "When burst heal target has HP>70%, EM+100 for 6s (assumes active)",
+        description: desc!("When burst heal target has HP>70%, EM+100 for 6s (assumes active)"),
         stat: BuffableStat::ElementalMastery,
         base_value: 100.0,
         scales_with_talent: false,
@@ -72,7 +72,7 @@ static JAHODA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "jahoda_c6_crit_rate",
-        description: "C6: Moonsign characters CRIT Rate +5%",
+        description: desc!("C6: Moonsign characters CRIT Rate +5%"),
         stat: BuffableStat::CritRate,
         base_value: 0.05,
         scales_with_talent: false,
@@ -86,7 +86,7 @@ static JAHODA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "jahoda_c6_crit_dmg",
-        description: "C6: Moonsign characters CRIT DMG +40%",
+        description: desc!("C6: Moonsign characters CRIT DMG +40%"),
         stat: BuffableStat::CritDmg,
         base_value: 0.40,
         scales_with_talent: false,
@@ -107,7 +107,9 @@ static JAHODA_BUFFS: &[TalentBuffDef] = &[
 static KAZUHA_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Poetics of Fuubutsu",
-        description: "After triggering Swirl, grants 0.04% Elemental DMG Bonus per point of EM",
+        description: desc!(
+            "After triggering Swirl, grants 0.04% Elemental DMG Bonus per point of EM"
+        ),
         stat: BuffableStat::DmgBonus,
         base_value: 0.0004,
         scales_with_talent: false,
@@ -121,7 +123,7 @@ static KAZUHA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "kazuha_c2_em",
-        description: "C2: Party EM +200 in Burst field",
+        description: desc!("C2: Party EM +200 in Burst field"),
         stat: BuffableStat::ElementalMastery,
         base_value: 200.0,
         scales_with_talent: false,
@@ -135,7 +137,7 @@ static KAZUHA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "kazuha_c6_normal_dmg",
-        description: "C6: Normal ATK DMG bonus based on 0.2% of EM",
+        description: desc!("C6: Normal ATK DMG bonus based on 0.2% of EM"),
         stat: BuffableStat::NormalAtkDmgBonus,
         base_value: 0.002,
         scales_with_talent: false,
@@ -149,7 +151,7 @@ static KAZUHA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "kazuha_c6_charged_dmg",
-        description: "C6: Charged ATK DMG bonus based on 0.2% of EM",
+        description: desc!("C6: Charged ATK DMG bonus based on 0.2% of EM"),
         stat: BuffableStat::ChargedAtkDmgBonus,
         base_value: 0.002,
         scales_with_talent: false,
@@ -163,7 +165,7 @@ static KAZUHA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "kazuha_c6_plunging_dmg",
-        description: "C6: Plunging ATK DMG bonus based on 0.2% of EM",
+        description: desc!("C6: Plunging ATK DMG bonus based on 0.2% of EM"),
         stat: BuffableStat::PlungingAtkDmgBonus,
         base_value: 0.002,
         scales_with_talent: false,
@@ -183,7 +185,9 @@ static KAZUHA_BUFFS: &[TalentBuffDef] = &[
 static SUCROSE_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Catalyst Conversion",
-        description: "After triggering Swirl, grants EM+50 to party members with matching element",
+        description: desc!(
+            "After triggering Swirl, grants EM+50 to party members with matching element"
+        ),
         stat: BuffableStat::ElementalMastery,
         base_value: 50.0,
         scales_with_talent: false,
@@ -197,7 +201,7 @@ static SUCROSE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Mollis Favonius",
-        description: "Shares 20% of Sucrose's EM to party",
+        description: desc!("Shares 20% of Sucrose's EM to party"),
         stat: BuffableStat::ElementalMastery,
         base_value: 0.20,
         scales_with_talent: false,
@@ -221,7 +225,9 @@ static SUCROSE_BUFFS: &[TalentBuffDef] = &[
 static VARKA_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Dawn Wind's March Anemo DMG",
-        description: "ATK1000あたり風元素DMG+10%、最大25%。対応元素DMG+25%は未実装(動的選択)。Toggle=25%想定",
+        description: desc!(
+            "ATK1000あたり風元素DMG+10%、最大25%。対応元素DMG+25%は未実装(動的選択)。Toggle=25%想定"
+        ),
         stat: BuffableStat::ElementalDmgBonus(Element::Anemo),
         base_value: 0.25,
         scales_with_talent: false,
@@ -235,7 +241,7 @@ static VARKA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Wind's Vanguard Normal ATK DMG",
-        description: "拡散反応時+7.5%/stack、最大4stack=30%。Toggle=4stack想定",
+        description: desc!("拡散反応時+7.5%/stack、最大4stack=30%。Toggle=4stack想定"),
         stat: BuffableStat::NormalAtkDmgBonus,
         base_value: 0.30,
         scales_with_talent: false,
@@ -249,7 +255,7 @@ static VARKA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Wind's Vanguard Charged ATK DMG",
-        description: "拡散反応時+7.5%/stack、最大4stack=30%。Toggle=4stack想定",
+        description: desc!("拡散反応時+7.5%/stack、最大4stack=30%。Toggle=4stack想定"),
         stat: BuffableStat::ChargedAtkDmgBonus,
         base_value: 0.30,
         scales_with_talent: false,
@@ -263,7 +269,7 @@ static VARKA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Freedom of Song Anemo DMG",
-        description: "C4: On Swirl, team Anemo DMG +20%",
+        description: desc!("C4: On Swirl, team Anemo DMG +20%"),
         stat: BuffableStat::ElementalDmgBonus(Element::Anemo),
         base_value: 0.20,
         scales_with_talent: false,
@@ -278,7 +284,7 @@ static VARKA_BUFFS: &[TalentBuffDef] = &[
     // C4 swirled element DMG +20% (element selected by Toggle; priority: Pyro > Hydro > Electro > Cryo)
     TalentBuffDef {
         name: "Freedom of Song Pyro DMG",
-        description: "C4: On Swirl, team Pyro DMG +20% (if Pyro swirled)",
+        description: desc!("C4: On Swirl, team Pyro DMG +20% (if Pyro swirled)"),
         stat: BuffableStat::ElementalDmgBonus(Element::Pyro),
         base_value: 0.20,
         scales_with_talent: false,
@@ -292,7 +298,7 @@ static VARKA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Freedom of Song Hydro DMG",
-        description: "C4: On Swirl, team Hydro DMG +20% (if Hydro swirled)",
+        description: desc!("C4: On Swirl, team Hydro DMG +20% (if Hydro swirled)"),
         stat: BuffableStat::ElementalDmgBonus(Element::Hydro),
         base_value: 0.20,
         scales_with_talent: false,
@@ -306,7 +312,7 @@ static VARKA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Freedom of Song Electro DMG",
-        description: "C4: On Swirl, team Electro DMG +20% (if Electro swirled)",
+        description: desc!("C4: On Swirl, team Electro DMG +20% (if Electro swirled)"),
         stat: BuffableStat::ElementalDmgBonus(Element::Electro),
         base_value: 0.20,
         scales_with_talent: false,
@@ -320,7 +326,7 @@ static VARKA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Freedom of Song Cryo DMG",
-        description: "C4: On Swirl, team Cryo DMG +20% (if Cryo swirled)",
+        description: desc!("C4: On Swirl, team Cryo DMG +20% (if Cryo swirled)"),
         stat: BuffableStat::ElementalDmgBonus(Element::Cryo),
         base_value: 0.20,
         scales_with_talent: false,
@@ -338,7 +344,7 @@ static VARKA_BUFFS: &[TalentBuffDef] = &[
 // C4: Anemo RES -40% in burst field
 static JEAN_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
     name: "Lands of Dandelion Anemo RES Shred",
-    description: "C4: Enemies inside Dandelion Field have Anemo RES -40%",
+    description: desc!("C4: Enemies inside Dandelion Field have Anemo RES -40%"),
     stat: BuffableStat::ElementalResReduction(Element::Anemo),
     base_value: 0.40,
     scales_with_talent: false,
@@ -358,7 +364,7 @@ static JEAN_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
 static VENTI_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Breeze of Reminiscence Anemo RES Shred",
-        description: "C2: Enemies hit by Skyward Sonnet have Anemo RES -12%",
+        description: desc!("C2: Enemies hit by Skyward Sonnet have Anemo RES -12%"),
         stat: BuffableStat::ElementalResReduction(Element::Anemo),
         base_value: 0.12,
         scales_with_talent: false,
@@ -372,7 +378,7 @@ static VENTI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Breeze of Reminiscence Physical RES Shred",
-        description: "C2: Enemies hit by Skyward Sonnet have Physical RES -12%",
+        description: desc!("C2: Enemies hit by Skyward Sonnet have Physical RES -12%"),
         stat: BuffableStat::PhysicalResReduction,
         base_value: 0.12,
         scales_with_talent: false,
@@ -386,7 +392,7 @@ static VENTI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "venti_c4_anemo_dmg",
-        description: "C4: Anemo DMG Bonus +25% on pickup",
+        description: desc!("C4: Anemo DMG Bonus +25% on pickup"),
         stat: BuffableStat::ElementalDmgBonus(Element::Anemo),
         base_value: 0.25,
         scales_with_talent: false,
@@ -400,7 +406,7 @@ static VENTI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "venti_c6_anemo_res_shred",
-        description: "C6: Opponents hit by Wind's Grand Ode have Anemo RES -20%",
+        description: desc!("C6: Opponents hit by Wind's Grand Ode have Anemo RES -20%"),
         stat: BuffableStat::ElementalResReduction(Element::Anemo),
         base_value: 0.20,
         scales_with_talent: false,
@@ -426,7 +432,7 @@ static XIANYUN_BURST_PLUNGE_SCALING: [f64; 15] = [
 static XIANYUN_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Stars Gather at Dusk Plunging Flat DMG",
-        description: "Burst: Plunging ATK gains flat DMG = total ATK × scaling (3 charges)",
+        description: desc!("Burst: Plunging ATK gains flat DMG = total ATK × scaling (3 charges)"),
         stat: BuffableStat::PlungingAtkFlatDmg,
         base_value: 0.0,
         scales_with_talent: true,
@@ -440,7 +446,7 @@ static XIANYUN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Crane Form Plunging DMG Bonus",
-        description: "A4: Plunging ATK DMG Bonus max +75% (adopting max value)",
+        description: desc!("A4: Plunging ATK DMG Bonus max +75% (adopting max value)"),
         stat: BuffableStat::PlungingAtkDmgBonus,
         base_value: 0.75,
         scales_with_talent: false,
@@ -454,7 +460,7 @@ static XIANYUN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Trivial Matters CritRate Bonus",
-        description: "C2: After burst, plunging attacks gain CritRate +20%",
+        description: desc!("C2: After burst, plunging attacks gain CritRate +20%"),
         stat: BuffableStat::CritRate,
         base_value: 0.20,
         scales_with_talent: false,
@@ -468,7 +474,7 @@ static XIANYUN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "xianyun_c2_atk",
-        description: "C2: ATK +20% after Skyladder",
+        description: desc!("C2: ATK +20% after Skyladder"),
         stat: BuffableStat::AtkPercent,
         base_value: 0.20,
         scales_with_talent: false,
@@ -482,7 +488,7 @@ static XIANYUN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "xianyun_c6_crit_dmg",
-        description: "C6: Max Driftcloud Wave CRIT DMG +70%",
+        description: desc!("C6: Max Driftcloud Wave CRIT DMG +70%"),
         stat: BuffableStat::CritDmg,
         base_value: 0.70,
         scales_with_talent: false,
@@ -502,7 +508,7 @@ static XIANYUN_BUFFS: &[TalentBuffDef] = &[
 static WANDERER_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Gales of Reverie ATK Bonus",
-        description: "A1: On Pyro contact during Windfavored state, ATK+30%",
+        description: desc!("A1: On Pyro contact during Windfavored state, ATK+30%"),
         stat: BuffableStat::AtkPercent,
         base_value: 0.30,
         scales_with_talent: false,
@@ -516,7 +522,7 @@ static WANDERER_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Gales of Reverie CritRate Bonus",
-        description: "A1: On Cryo contact during Windfavored state, CritRate+20%",
+        description: desc!("A1: On Cryo contact during Windfavored state, CritRate+20%"),
         stat: BuffableStat::CritRate,
         base_value: 0.20,
         scales_with_talent: false,
@@ -530,7 +536,7 @@ static WANDERER_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Stormborne Burst DMG Bonus",
-        description: "C2: Hanega: Song of the Wind DMG up to +200% (max value)",
+        description: desc!("C2: Hanega: Song of the Wind DMG up to +200% (max value)"),
         stat: BuffableStat::BurstDmgBonus,
         base_value: 2.00,
         scales_with_talent: false,
@@ -551,7 +557,9 @@ static WANDERER_BUFFS: &[TalentBuffDef] = &[
 static XIAO_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Transcension: Gravity Defier DMG Bonus",
-        description: "A4: DMG+5% every 3s in Yaksha's Mask, max 5 stacks (+25%). Toggle = max value",
+        description: desc!(
+            "A4: DMG+5% every 3s in Yaksha's Mask, max 5 stacks (+25%). Toggle = max value"
+        ),
         stat: BuffableStat::DmgBonus,
         base_value: 0.25,
         scales_with_talent: false,
@@ -565,7 +573,7 @@ static XIAO_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Conqueror of Evil: Tamer of Demons DEF Bonus",
-        description: "C4: When HP<50%, DEF+100%",
+        description: desc!("C4: When HP<50%, DEF+100%"),
         stat: BuffableStat::DefPercent,
         base_value: 1.00,
         scales_with_talent: false,
@@ -585,7 +593,7 @@ static XIAO_BUFFS: &[TalentBuffDef] = &[
 static CHASCA_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Galesplitting Soulseeker Shell Skill DMG Bonus",
-        description: "A1: Skill DMG+15/35/65% based on element count. Toggle = max 65%",
+        description: desc!("A1: Skill DMG+15/35/65% based on element count. Toggle = max 65%"),
         stat: BuffableStat::SkillDmgBonus,
         base_value: 0.65,
         scales_with_talent: false,
@@ -599,7 +607,7 @@ static CHASCA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Ride the Wind CritDmg Bonus",
-        description: "C6: CritDmg+120%",
+        description: desc!("C6: CritDmg+120%"),
         stat: BuffableStat::CritDmg,
         base_value: 1.20,
         scales_with_talent: false,
@@ -619,7 +627,7 @@ static CHASCA_BUFFS: &[TalentBuffDef] = &[
 static HEIZOU_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Penetrative Reasoning EM Bonus",
-        description: "A4: After using Elemental Burst, team EM+80 for 10s",
+        description: desc!("A4: After using Elemental Burst, team EM+80 for 10s"),
         stat: BuffableStat::ElementalMastery,
         base_value: 80.0,
         scales_with_talent: false,
@@ -633,7 +641,9 @@ static HEIZOU_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Paradoxical Practice CritRate Bonus",
-        description: "C6: CritRate+4%/Declension stack, max 4 stacks (+16%). Toggle = max value",
+        description: desc!(
+            "C6: CritRate+4%/Declension stack, max 4 stacks (+16%). Toggle = max value"
+        ),
         stat: BuffableStat::CritRate,
         base_value: 0.16,
         scales_with_talent: false,
@@ -647,7 +657,7 @@ static HEIZOU_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Paradoxical Practice CritDmg Bonus",
-        description: "C6: CritDmg+32% at max Declension stacks",
+        description: desc!("C6: CritDmg+32% at max Declension stacks"),
         stat: BuffableStat::CritDmg,
         base_value: 0.32,
         scales_with_talent: false,
@@ -667,7 +677,7 @@ static HEIZOU_BUFFS: &[TalentBuffDef] = &[
 // TODO: A4 — Swirl/EC DMG scaling from Nightsoul points; too complex for TalentBuffDef
 static IFA_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
     name: "Eye of Stormy Judgment EM Bonus",
-    description: "C4: EM+100",
+    description: desc!("C4: EM+100"),
     stat: BuffableStat::ElementalMastery,
     base_value: 100.0,
     scales_with_talent: false,
@@ -686,7 +696,9 @@ static IFA_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
 static LAN_YAN_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Lan Yan A4 Normal ATK Flat DMG",
-        description: "A4: Normal ATK flat DMG up to 774% EM. Toggle = max value (base_value=7.74 × EM)",
+        description: desc!(
+            "A4: Normal ATK flat DMG up to 774% EM. Toggle = max value (base_value=7.74 × EM)"
+        ),
         stat: BuffableStat::NormalAtkFlatDmg,
         base_value: 7.74,
         scales_with_talent: false,
@@ -700,7 +712,7 @@ static LAN_YAN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Lan Yan C4 Team EM Bonus",
-        description: "C4: team EM+60",
+        description: desc!("C4: team EM+60"),
         stat: BuffableStat::ElementalMastery,
         base_value: 60.0,
         scales_with_talent: false,
@@ -720,7 +732,7 @@ static LAN_YAN_BUFFS: &[TalentBuffDef] = &[
 static LYNETTE_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Sophisticated Synergy ATK Bonus",
-        description: "A4: team ATK+8~20% based on element diversity. Toggle = max 20%",
+        description: desc!("A4: team ATK+8~20% based on element diversity. Toggle = max 20%"),
         stat: BuffableStat::AtkPercent,
         base_value: 0.20,
         scales_with_talent: false,
@@ -734,7 +746,7 @@ static LYNETTE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Magic Trick: Astonishing Shift Anemo DMG Bonus",
-        description: "C6: Anemo DMG Bonus+20%",
+        description: desc!("C6: Anemo DMG Bonus+20%"),
         stat: BuffableStat::ElementalDmgBonus(Element::Anemo),
         base_value: 0.20,
         scales_with_talent: false,
@@ -755,7 +767,7 @@ static LYNETTE_BUFFS: &[TalentBuffDef] = &[
 static MIZUKI_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Mizuki A1 Team EM Bonus",
-        description: "A1 passive: team EM+100 (always active)",
+        description: desc!("A1 passive: team EM+100 (always active)"),
         stat: BuffableStat::ElementalMastery,
         base_value: 100.0,
         scales_with_talent: false,
@@ -769,7 +781,7 @@ static MIZUKI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Mizuki C2 Team DMG Bonus",
-        description: "C2: team DMG+0.04%/EM (base_value=0.0004 × EM)",
+        description: desc!("C2: team DMG+0.04%/EM (base_value=0.0004 × EM)"),
         stat: BuffableStat::DmgBonus,
         base_value: 0.0004,
         scales_with_talent: false,
@@ -783,7 +795,7 @@ static MIZUKI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Mizuki C6 Swirl CritRate Bonus",
-        description: "C6: Swirl CritRate+30%",
+        description: desc!("C6: Swirl CritRate+30%"),
         stat: BuffableStat::CritRate,
         base_value: 0.30,
         scales_with_talent: false,
@@ -797,7 +809,7 @@ static MIZUKI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Mizuki C6 Swirl CritDmg Bonus",
-        description: "C6: Swirl CritDmg+100%",
+        description: desc!("C6: Swirl CritDmg+100%"),
         stat: BuffableStat::CritDmg,
         base_value: 1.00,
         scales_with_talent: false,
@@ -817,7 +829,7 @@ static MIZUKI_BUFFS: &[TalentBuffDef] = &[
 // TODO: C6 — EM-scaling Daruma DMG; too complex for TalentBuffDef
 static SAYU_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
     name: "Sayu C2 Skill DMG Bonus",
-    description: "C2: Skill DMG up to +66% based on EM. Toggle = max value",
+    description: desc!("C2: Skill DMG up to +66% based on EM. Toggle = max value"),
     stat: BuffableStat::SkillDmgBonus,
     base_value: 0.66,
     scales_with_talent: false,

--- a/crates/data/src/talent_buffs/cryo.rs
+++ b/crates/data/src/talent_buffs/cryo.rs
@@ -4,7 +4,7 @@ use super::*;
 // C6 "Cat's Tail Closing Time": EM+200 in burst field
 static DIONA_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
     name: "Cat's Tail Closing Time",
-    description: "Characters within burst field gain EM+200",
+    description: desc!("Characters within burst field gain EM+200"),
     stat: BuffableStat::ElementalMastery,
     base_value: 200.0,
     scales_with_talent: false,
@@ -24,7 +24,7 @@ static DIONA_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
 static GANYU_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Harmony between Heaven and Earth",
-        description: "Cryo DMG Bonus +20% for party members in burst field",
+        description: desc!("Cryo DMG Bonus +20% for party members in burst field"),
         stat: BuffableStat::ElementalDmgBonus(Element::Cryo),
         base_value: 0.20,
         scales_with_talent: false,
@@ -38,7 +38,7 @@ static GANYU_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Westward Sojourn DmgBonus",
-        description: "C4: In burst field, DMG+5% every 3s (max +25%, adopting max value)",
+        description: desc!("C4: In burst field, DMG+5% every 3s (max +25%, adopting max value)"),
         stat: BuffableStat::DmgBonus,
         base_value: 0.25,
         scales_with_talent: false,
@@ -52,7 +52,7 @@ static GANYU_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "ganyu_c1_cryo_res_shred",
-        description: "C1: Frostflake Arrow hit reduces Cryo RES -15%",
+        description: desc!("C1: Frostflake Arrow hit reduces Cryo RES -15%"),
         stat: BuffableStat::ElementalResReduction(Element::Cryo),
         base_value: 0.15,
         scales_with_talent: false,
@@ -71,7 +71,7 @@ static GANYU_BUFFS: &[TalentBuffDef] = &[
 static QIQI_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "qiqi_c2_normal_dmg",
-        description: "C2: Normal ATK DMG +15% vs Cryo-affected opponents",
+        description: desc!("C2: Normal ATK DMG +15% vs Cryo-affected opponents"),
         stat: BuffableStat::NormalAtkDmgBonus,
         base_value: 0.15,
         scales_with_talent: false,
@@ -85,7 +85,7 @@ static QIQI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "qiqi_c2_charged_dmg",
-        description: "C2: Charged ATK DMG +15% vs Cryo-affected opponents",
+        description: desc!("C2: Charged ATK DMG +15% vs Cryo-affected opponents"),
         stat: BuffableStat::ChargedAtkDmgBonus,
         base_value: 0.15,
         scales_with_talent: false,
@@ -106,7 +106,7 @@ static QIQI_BUFFS: &[TalentBuffDef] = &[
 static ROSARIA_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Shadow Samaritan CRIT Rate Share",
-        description: "After burst, grants 15% of Rosaria's CRIT Rate to party (max 15%)",
+        description: desc!("After burst, grants 15% of Rosaria's CRIT Rate to party (max 15%)"),
         stat: BuffableStat::CritRate,
         base_value: 0.15,
         scales_with_talent: false,
@@ -120,7 +120,7 @@ static ROSARIA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Rites of Termination Physical RES Shred",
-        description: "C6: Enemies hit by burst have Physical RES -20% for 10s",
+        description: desc!("C6: Enemies hit by burst have Physical RES -20% for 10s"),
         stat: BuffableStat::PhysicalResReduction,
         base_value: 0.20,
         scales_with_talent: false,
@@ -134,7 +134,7 @@ static ROSARIA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "rosaria_c1_normal_dmg",
-        description: "C1: Normal ATK DMG +10% on CRIT hit",
+        description: desc!("C1: Normal ATK DMG +10% on CRIT hit"),
         stat: BuffableStat::NormalAtkDmgBonus,
         base_value: 0.10,
         scales_with_talent: false,
@@ -158,7 +158,7 @@ static SHENHE_SKILL_SCALING: [f64; 15] = [
 static SHENHE_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Spring Spirit Summoning Normal ATK Flat DMG",
-        description: "Adds flat Cryo DMG based on Shenhe's ATK to party's Normal Attacks",
+        description: desc!("Adds flat Cryo DMG based on Shenhe's ATK to party's Normal Attacks"),
         stat: BuffableStat::NormalAtkFlatDmg,
         base_value: 0.0,
         scales_with_talent: true,
@@ -172,7 +172,7 @@ static SHENHE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Spring Spirit Summoning Charged ATK Flat DMG",
-        description: "Adds flat Cryo DMG based on Shenhe's ATK to party's Charged Attacks",
+        description: desc!("Adds flat Cryo DMG based on Shenhe's ATK to party's Charged Attacks"),
         stat: BuffableStat::ChargedAtkFlatDmg,
         base_value: 0.0,
         scales_with_talent: true,
@@ -186,7 +186,7 @@ static SHENHE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Spring Spirit Summoning Plunging ATK Flat DMG",
-        description: "Adds flat Cryo DMG based on Shenhe's ATK to party's Plunging Attacks",
+        description: desc!("Adds flat Cryo DMG based on Shenhe's ATK to party's Plunging Attacks"),
         stat: BuffableStat::PlungingAtkFlatDmg,
         base_value: 0.0,
         scales_with_talent: true,
@@ -200,7 +200,7 @@ static SHENHE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Spring Spirit Summoning Skill Flat DMG",
-        description: "Adds flat Cryo DMG based on Shenhe's ATK to party's Elemental Skills",
+        description: desc!("Adds flat Cryo DMG based on Shenhe's ATK to party's Elemental Skills"),
         stat: BuffableStat::SkillFlatDmg,
         base_value: 0.0,
         scales_with_talent: true,
@@ -214,7 +214,7 @@ static SHENHE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Spring Spirit Summoning Burst Flat DMG",
-        description: "Adds flat Cryo DMG based on Shenhe's ATK to party's Elemental Bursts",
+        description: desc!("Adds flat Cryo DMG based on Shenhe's ATK to party's Elemental Bursts"),
         stat: BuffableStat::BurstFlatDmg,
         base_value: 0.0,
         scales_with_talent: true,
@@ -229,7 +229,7 @@ static SHENHE_BUFFS: &[TalentBuffDef] = &[
     // A4 "Deific Embrace" Press E: Skill/Burst DMG +15%
     TalentBuffDef {
         name: "Deific Embrace Press - Skill DMG",
-        description: "After press E, party Skill DMG +15% for 10s",
+        description: desc!("After press E, party Skill DMG +15% for 10s"),
         stat: BuffableStat::SkillDmgBonus,
         base_value: 0.15,
         scales_with_talent: false,
@@ -243,7 +243,7 @@ static SHENHE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Deific Embrace Press - Burst DMG",
-        description: "After press E, party Burst DMG +15% for 10s",
+        description: desc!("After press E, party Burst DMG +15% for 10s"),
         stat: BuffableStat::BurstDmgBonus,
         base_value: 0.15,
         scales_with_talent: false,
@@ -258,7 +258,7 @@ static SHENHE_BUFFS: &[TalentBuffDef] = &[
     // A4 "Deific Embrace" Hold E: Normal/Charged/Plunging ATK DMG +15%
     TalentBuffDef {
         name: "Deific Embrace Hold - Normal ATK DMG",
-        description: "After hold E, party Normal ATK DMG +15% for 15s",
+        description: desc!("After hold E, party Normal ATK DMG +15% for 15s"),
         stat: BuffableStat::NormalAtkDmgBonus,
         base_value: 0.15,
         scales_with_talent: false,
@@ -272,7 +272,7 @@ static SHENHE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Deific Embrace Hold - Charged ATK DMG",
-        description: "After hold E, party Charged ATK DMG +15% for 15s",
+        description: desc!("After hold E, party Charged ATK DMG +15% for 15s"),
         stat: BuffableStat::ChargedAtkDmgBonus,
         base_value: 0.15,
         scales_with_talent: false,
@@ -286,7 +286,7 @@ static SHENHE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Deific Embrace Hold - Plunging ATK DMG",
-        description: "After hold E, party Plunging ATK DMG +15% for 15s",
+        description: desc!("After hold E, party Plunging ATK DMG +15% for 15s"),
         stat: BuffableStat::PlungingAtkDmgBonus,
         base_value: 0.15,
         scales_with_talent: false,
@@ -301,7 +301,7 @@ static SHENHE_BUFFS: &[TalentBuffDef] = &[
     // C2 "Centered Spirit": Cryo CRIT DMG +15% in Burst field
     TalentBuffDef {
         name: "shenhe_c2_cryo_crit_dmg",
-        description: "C2: Cryo CRIT DMG +15% in Burst field",
+        description: desc!("C2: Cryo CRIT DMG +15% in Burst field"),
         stat: BuffableStat::CritDmg,
         base_value: 0.15,
         scales_with_talent: false,
@@ -323,7 +323,7 @@ static SHENHE_BUFFS: &[TalentBuffDef] = &[
 static CITLALI_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Itzpapa Pyro RES Shred",
-        description: "Skill: Enemy Pyro RES -20% while Itzpapa is active",
+        description: desc!("Skill: Enemy Pyro RES -20% while Itzpapa is active"),
         stat: BuffableStat::ElementalResReduction(Element::Pyro),
         base_value: 0.20,
         scales_with_talent: false,
@@ -337,7 +337,7 @@ static CITLALI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Itzpapa Hydro RES Shred",
-        description: "Skill: Enemy Hydro RES -20% while Itzpapa is active",
+        description: desc!("Skill: Enemy Hydro RES -20% while Itzpapa is active"),
         stat: BuffableStat::ElementalResReduction(Element::Hydro),
         base_value: 0.20,
         scales_with_talent: false,
@@ -351,7 +351,9 @@ static CITLALI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Heart Devourer's Travail EM Bonus",
-        description: "C2: While Opal Shield is active or Itzpapa is following, nearby party members (excl. Citlali) gain EM+250",
+        description: desc!(
+            "C2: While Opal Shield is active or Itzpapa is following, nearby party members (excl. Citlali) gain EM+250"
+        ),
         stat: BuffableStat::ElementalMastery,
         base_value: 250.0,
         scales_with_talent: false,
@@ -365,7 +367,7 @@ static CITLALI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Cold Moon Pyro RES Shred",
-        description: "C2: Additional Pyro RES -20% (cumulative with Skill: total -40%)",
+        description: desc!("C2: Additional Pyro RES -20% (cumulative with Skill: total -40%)"),
         stat: BuffableStat::ElementalResReduction(Element::Pyro),
         base_value: 0.20,
         scales_with_talent: false,
@@ -379,7 +381,7 @@ static CITLALI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Cold Moon Hydro RES Shred",
-        description: "C2: Additional Hydro RES -20% (cumulative with Skill: total -40%)",
+        description: desc!("C2: Additional Hydro RES -20% (cumulative with Skill: total -40%)"),
         stat: BuffableStat::ElementalResReduction(Element::Hydro),
         base_value: 0.20,
         scales_with_talent: false,
@@ -393,7 +395,9 @@ static CITLALI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Secret Pact Pyro DMG Bonus",
-        description: "C6: Mystic Counts grant Pyro DMG +1.5% per count (max 40 counts = +60%)",
+        description: desc!(
+            "C6: Mystic Counts grant Pyro DMG +1.5% per count (max 40 counts = +60%)"
+        ),
         stat: BuffableStat::ElementalDmgBonus(Element::Pyro),
         base_value: 0.015,
         scales_with_talent: false,
@@ -407,7 +411,9 @@ static CITLALI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Secret Pact Hydro DMG Bonus",
-        description: "C6: Mystic Counts grant Hydro DMG +1.5% per count (max 40 counts = +60%)",
+        description: desc!(
+            "C6: Mystic Counts grant Hydro DMG +1.5% per count (max 40 counts = +60%)"
+        ),
         stat: BuffableStat::ElementalDmgBonus(Element::Hydro),
         base_value: 0.015,
         scales_with_talent: false,
@@ -428,7 +434,7 @@ static CITLALI_BUFFS: &[TalentBuffDef] = &[
 static EULA_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Icetide Vortex Cryo RES Shred",
-        description: "Hold Skill: Enemy Cryo RES -25% per Grimheart stack (max 2)",
+        description: desc!("Hold Skill: Enemy Cryo RES -25% per Grimheart stack (max 2)"),
         stat: BuffableStat::ElementalResReduction(Element::Cryo),
         base_value: 0.25,
         scales_with_talent: false,
@@ -442,7 +448,7 @@ static EULA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Icetide Vortex Physical RES Shred",
-        description: "Hold Skill: Enemy Physical RES -25% per Grimheart stack (max 2)",
+        description: desc!("Hold Skill: Enemy Physical RES -25% per Grimheart stack (max 2)"),
         stat: BuffableStat::PhysicalResReduction,
         base_value: 0.25,
         scales_with_talent: false,
@@ -456,7 +462,7 @@ static EULA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "eula_c1_physical_dmg",
-        description: "C1: Physical DMG Bonus +30% on Grimheart consume",
+        description: desc!("C1: Physical DMG Bonus +30% on Grimheart consume"),
         stat: BuffableStat::PhysicalDmgBonus,
         base_value: 0.30,
         scales_with_talent: false,
@@ -470,7 +476,7 @@ static EULA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "eula_c4_burst_dmg",
-        description: "C4: Burst DMG +25% vs opponents below 50% HP",
+        description: desc!("C4: Burst DMG +25% vs opponents below 50% HP"),
         stat: BuffableStat::BurstDmgBonus,
         base_value: 0.25,
         scales_with_talent: false,
@@ -490,7 +496,7 @@ static EULA_BUFFS: &[TalentBuffDef] = &[
 static MIKA_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Blood-Red Bristles Physical DMG Bonus",
-        description: "C6: During Skyfeather Song recovery, Physical DMG +10% (HP>50%)",
+        description: desc!("C6: During Skyfeather Song recovery, Physical DMG +10% (HP>50%)"),
         stat: BuffableStat::PhysicalDmgBonus,
         base_value: 0.10,
         scales_with_talent: false,
@@ -504,7 +510,7 @@ static MIKA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "mika_c6_physical_crit_dmg",
-        description: "C6: Physical CRIT DMG +60%",
+        description: desc!("C6: Physical CRIT DMG +60%"),
         stat: BuffableStat::CritDmg,
         base_value: 0.60,
         scales_with_talent: false,
@@ -524,7 +530,7 @@ static MIKA_BUFFS: &[TalentBuffDef] = &[
 static ALOY_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Easy Does It ATK Self",
-        description: "A1: After receiving Coil stacks, Aloy's ATK +16%",
+        description: desc!("A1: After receiving Coil stacks, Aloy's ATK +16%"),
         stat: BuffableStat::AtkPercent,
         base_value: 0.16,
         scales_with_talent: false,
@@ -538,7 +544,9 @@ static ALOY_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Easy Does It ATK Team",
-        description: "A1: After receiving Coil stacks, nearby party members (excl. Aloy) gain ATK+8%",
+        description: desc!(
+            "A1: After receiving Coil stacks, nearby party members (excl. Aloy) gain ATK+8%"
+        ),
         stat: BuffableStat::AtkPercent,
         base_value: 0.08,
         scales_with_talent: false,
@@ -552,7 +560,9 @@ static ALOY_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Strong Strike Cryo DMG",
-        description: "A4: In Rushing Ice state, Cryo DMG+3.5%/s (max +35%, adopting max value)",
+        description: desc!(
+            "A4: In Rushing Ice state, Cryo DMG+3.5%/s (max +35%, adopting max value)"
+        ),
         stat: BuffableStat::ElementalDmgBonus(Element::Cryo),
         base_value: 0.35,
         scales_with_talent: false,
@@ -574,7 +584,7 @@ static ALOY_BUFFS: &[TalentBuffDef] = &[
 static AYAKA_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Amatsumi Kunitsumi Sanctification Normal ATK",
-        description: "A1: After using Skill, Normal ATK DMG+30% for 6s",
+        description: desc!("A1: After using Skill, Normal ATK DMG+30% for 6s"),
         stat: BuffableStat::NormalAtkDmgBonus,
         base_value: 0.30,
         scales_with_talent: false,
@@ -588,7 +598,7 @@ static AYAKA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Amatsumi Kunitsumi Sanctification Charged ATK",
-        description: "A1: After using Skill, Charged ATK DMG+30% for 6s",
+        description: desc!("A1: After using Skill, Charged ATK DMG+30% for 6s"),
         stat: BuffableStat::ChargedAtkDmgBonus,
         base_value: 0.30,
         scales_with_talent: false,
@@ -602,7 +612,7 @@ static AYAKA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Kanten Senmyou Blessing Cryo DMG",
-        description: "A4: After using Burst, Cryo DMG+18% for 10s",
+        description: desc!("A4: After using Burst, Cryo DMG+18% for 10s"),
         stat: BuffableStat::ElementalDmgBonus(Element::Cryo),
         base_value: 0.18,
         scales_with_talent: false,
@@ -616,7 +626,7 @@ static AYAKA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Ebb and Flow DEF Shred",
-        description: "C4: Enemies hit by burst have DEF-30% for 6s",
+        description: desc!("C4: Enemies hit by burst have DEF-30% for 6s"),
         stat: BuffableStat::DefReduction,
         base_value: 0.30,
         scales_with_talent: false,
@@ -630,7 +640,7 @@ static AYAKA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Flowers of the Freesia State CA DMG",
-        description: "C6: During Burst, Charged ATK DMG+298%",
+        description: desc!("C6: During Burst, Charged ATK DMG+298%"),
         stat: BuffableStat::ChargedAtkDmgBonus,
         base_value: 2.98,
         scales_with_talent: false,
@@ -650,7 +660,7 @@ static AYAKA_BUFFS: &[TalentBuffDef] = &[
 static CHARLOTTE_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Cherished Discourse ATK",
-        description: "C2: Each time Skill hits, ATK+10% per stack (max 3 stacks)",
+        description: desc!("C2: Each time Skill hits, ATK+10% per stack (max 3 stacks)"),
         stat: BuffableStat::AtkPercent,
         base_value: 0.10,
         scales_with_talent: false,
@@ -664,7 +674,7 @@ static CHARLOTTE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Biting Cold Burst DMG",
-        description: "C4: Burst DMG+10%",
+        description: desc!("C4: Burst DMG+10%"),
         stat: BuffableStat::BurstDmgBonus,
         base_value: 0.10,
         scales_with_talent: false,
@@ -684,7 +694,7 @@ static CHARLOTTE_BUFFS: &[TalentBuffDef] = &[
 static CHONGYUN_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Rimechaser Blade Cryo RES Shred",
-        description: "A4: After Skill field ends, enemy Cryo RES -10% for 8s",
+        description: desc!("A4: After Skill field ends, enemy Cryo RES -10% for 8s"),
         stat: BuffableStat::ElementalResReduction(Element::Cryo),
         base_value: 0.10,
         scales_with_talent: false,
@@ -698,7 +708,7 @@ static CHONGYUN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Rally of Four Blades DMG Bonus",
-        description: "C6: DMG+15% (self)",
+        description: desc!("C6: DMG+15% (self)"),
         stat: BuffableStat::DmgBonus,
         base_value: 0.15,
         scales_with_talent: false,
@@ -718,7 +728,7 @@ static CHONGYUN_BUFFS: &[TalentBuffDef] = &[
 static ESCOFFIER_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Amuse-bouche de Saveur Cryo CD",
-        description: "C1: Party Cryo CRIT DMG+60%",
+        description: desc!("C1: Party Cryo CRIT DMG+60%"),
         stat: BuffableStat::CritDmg,
         base_value: 0.60,
         scales_with_talent: false,
@@ -732,7 +742,7 @@ static ESCOFFIER_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "escoffier_c1_cryo_crit_dmg",
-        description: "C1: Cryo CRIT DMG +60% (requires 4 Hydro/Cryo party members)",
+        description: desc!("C1: Cryo CRIT DMG +60% (requires 4 Hydro/Cryo party members)"),
         stat: BuffableStat::CritDmg,
         base_value: 0.60,
         scales_with_talent: false,
@@ -746,7 +756,7 @@ static ESCOFFIER_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "escoffier_c2_skill_flat_dmg",
-        description: "C2: Skill DMG bonus based on 240% of Total ATK",
+        description: desc!("C2: Skill DMG bonus based on 240% of Total ATK"),
         stat: BuffableStat::SkillFlatDmg,
         base_value: 2.40,
         scales_with_talent: false,
@@ -768,7 +778,7 @@ static ESCOFFIER_BUFFS: &[TalentBuffDef] = &[
 static FREMINET_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Deepwater Swim Shatter DMG",
-        description: "A4: Shatter DMG+40%",
+        description: desc!("A4: Shatter DMG+40%"),
         stat: BuffableStat::TransformativeBonus,
         base_value: 0.40,
         scales_with_talent: false,
@@ -782,7 +792,7 @@ static FREMINET_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Dreams of the Foamy Deep CR",
-        description: "C1: CR+15%",
+        description: desc!("C1: CR+15%"),
         stat: BuffableStat::CritRate,
         base_value: 0.15,
         scales_with_talent: false,
@@ -796,7 +806,7 @@ static FREMINET_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Secret Plan to Freeze ATK",
-        description: "C4: ATK+9% per stack when Pers Timer hits (max 2 stacks)",
+        description: desc!("C4: ATK+9% per stack when Pers Timer hits (max 2 stacks)"),
         stat: BuffableStat::AtkPercent,
         base_value: 0.09,
         scales_with_talent: false,
@@ -810,7 +820,7 @@ static FREMINET_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Moment of Waking CD",
-        description: "C6: CD+12% per Shattering hit (max 3 stacks)",
+        description: desc!("C6: CD+12% per Shattering hit (max 3 stacks)"),
         stat: BuffableStat::CritDmg,
         base_value: 0.12,
         scales_with_talent: false,
@@ -828,7 +838,7 @@ static FREMINET_BUFFS: &[TalentBuffDef] = &[
 // C1 "Excellent Blood": CR+15% vs Cryo-affected enemies (Team)
 static KAEYA_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
     name: "Excellent Blood CR",
-    description: "C1: CR+15% vs Cryo-affected enemies (Team)",
+    description: desc!("C1: CR+15% vs Cryo-affected enemies (Team)"),
     stat: BuffableStat::CritRate,
     base_value: 0.15,
     scales_with_talent: false,
@@ -849,7 +859,9 @@ static KAEYA_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
 static LAYLA_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Like Nascent Light Shield Strength",
-        description: "A1: Shield Str+6%/stack when Night Star is absorbed (max 4 stacks, adopting max +24%)",
+        description: desc!(
+            "A1: Shield Str+6%/stack when Night Star is absorbed (max 4 stacks, adopting max +24%)"
+        ),
         stat: BuffableStat::ShieldStrength,
         base_value: 0.24,
         scales_with_talent: false,
@@ -863,7 +875,7 @@ static LAYLA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Sweet Slumber Undisturbed Shooting Star DMG",
-        description: "A4: Shooting Stars deal flat DMG = 1.5% of Layla's HP",
+        description: desc!("A4: Shooting Stars deal flat DMG = 1.5% of Layla's HP"),
         stat: BuffableStat::SkillFlatDmg,
         base_value: 0.015,
         scales_with_talent: false,
@@ -877,7 +889,7 @@ static LAYLA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Starry Illumination Normal ATK Flat DMG",
-        description: "C4: Normal ATK flat DMG = 5% of Layla's HP",
+        description: desc!("C4: Normal ATK flat DMG = 5% of Layla's HP"),
         stat: BuffableStat::NormalAtkFlatDmg,
         base_value: 0.05,
         scales_with_talent: false,
@@ -891,7 +903,7 @@ static LAYLA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Starry Illumination Charged ATK Flat DMG",
-        description: "C4: Charged ATK flat DMG = 5% of Layla's HP",
+        description: desc!("C4: Charged ATK flat DMG = 5% of Layla's HP"),
         stat: BuffableStat::ChargedAtkFlatDmg,
         base_value: 0.05,
         scales_with_talent: false,
@@ -905,7 +917,7 @@ static LAYLA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Boundless Radiance Shooting Star DMG",
-        description: "C6: Shooting Stars DMG+40%",
+        description: desc!("C6: Shooting Stars DMG+40%"),
         stat: BuffableStat::SkillDmgBonus,
         base_value: 0.40,
         scales_with_talent: false,
@@ -925,7 +937,7 @@ static LAYLA_BUFFS: &[TalentBuffDef] = &[
 static SKIRK_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Liminal Crossing ATK",
-        description: "C2: ATK+70% (self)",
+        description: desc!("C2: ATK+70% (self)"),
         stat: BuffableStat::AtkPercent,
         base_value: 0.70,
         scales_with_talent: false,
@@ -939,7 +951,7 @@ static SKIRK_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Fractured Boundary ATK",
-        description: "C4: ATK+10/20/40% based on stacks (adopting max +40%, self)",
+        description: desc!("C4: ATK+10/20/40% based on stacks (adopting max +40%, self)"),
         stat: BuffableStat::AtkPercent,
         base_value: 0.40,
         scales_with_talent: false,
@@ -959,7 +971,7 @@ static SKIRK_BUFFS: &[TalentBuffDef] = &[
 static WRIOTHESLEY_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "There Shall Be a Plea for Justice ATK",
-        description: "A4: ATK+6% per stack on consecutive CA hits (max 5 stacks = +30%)",
+        description: desc!("A4: ATK+6% per stack on consecutive CA hits (max 5 stacks = +30%)"),
         stat: BuffableStat::AtkPercent,
         base_value: 0.06,
         scales_with_talent: false,
@@ -973,7 +985,7 @@ static WRIOTHESLEY_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Pax Perpetua CR",
-        description: "C6: During Darkgold state, CR+10%",
+        description: desc!("C6: During Darkgold state, CR+10%"),
         stat: BuffableStat::CritRate,
         base_value: 0.10,
         scales_with_talent: false,
@@ -987,7 +999,7 @@ static WRIOTHESLEY_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Pax Perpetua CD",
-        description: "C6: During Darkgold state, CD+80%",
+        description: desc!("C6: During Darkgold state, CD+80%"),
         stat: BuffableStat::CritDmg,
         base_value: 0.80,
         scales_with_talent: false,

--- a/crates/data/src/talent_buffs/dendro.rs
+++ b/crates/data/src/talent_buffs/dendro.rs
@@ -4,7 +4,7 @@ use super::*;
 // A4 passive "Cleansing for the Spring": Elemental Skill DMG +0.04% per point of EM (max +32% at 800 EM)
 static LAUMA_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
     name: "Cleansing for the Spring",
-    description: "A4: Elemental Skill DMG +0.04% per point of EM (max +32% at 800 EM)",
+    description: desc!("A4: Elemental Skill DMG +0.04% per point of EM (max +32% at 800 EM)"),
     stat: BuffableStat::SkillDmgBonus,
     base_value: 0.0004,
     scales_with_talent: false,
@@ -26,7 +26,7 @@ static LAUMA_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
 static NAHIDA_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Compassion Illuminated",
-        description: "A1: Grants EM to party = highest_party_EM × 25%, max 250",
+        description: desc!("A1: Grants EM to party = highest_party_EM × 25%, max 250"),
         stat: BuffableStat::ElementalMastery,
         base_value: 0.25,
         scales_with_talent: false,
@@ -40,7 +40,7 @@ static NAHIDA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "nahida_c2_crit_rate",
-        description: "C2: Reaction CRIT Rate +20%",
+        description: desc!("C2: Reaction CRIT Rate +20%"),
         stat: BuffableStat::CritRate,
         base_value: 0.20,
         scales_with_talent: false,
@@ -54,7 +54,7 @@ static NAHIDA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "nahida_c2_crit_dmg",
-        description: "C2: Reaction CRIT DMG +100%",
+        description: desc!("C2: Reaction CRIT DMG +100%"),
         stat: BuffableStat::CritDmg,
         base_value: 1.00,
         scales_with_talent: false,
@@ -68,7 +68,7 @@ static NAHIDA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "nahida_c2_def_reduction",
-        description: "C2: DEF -30% on Quicken/Aggravate/Spread",
+        description: desc!("C2: DEF -30% on Quicken/Aggravate/Spread"),
         stat: BuffableStat::DefReduction,
         base_value: 0.30,
         scales_with_talent: false,
@@ -82,7 +82,7 @@ static NAHIDA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "nahida_c4_em",
-        description: "C4: EM +100 per nearby Skandha enemy (max 4)",
+        description: desc!("C4: EM +100 per nearby Skandha enemy (max 4)"),
         stat: BuffableStat::ElementalMastery,
         base_value: 100.0,
         scales_with_talent: false,
@@ -103,7 +103,7 @@ static NAHIDA_BUFFS: &[TalentBuffDef] = &[
 static NEFER_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Observation Feeds Strategy EM Bonus",
-        description: "C2: EM +200 at 5 Veil of Falsehood stacks",
+        description: desc!("C2: EM +200 at 5 Veil of Falsehood stacks"),
         stat: BuffableStat::ElementalMastery,
         base_value: 200.0,
         scales_with_talent: false,
@@ -117,7 +117,7 @@ static NEFER_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Delusion Ensnares Reason Dendro RES Down",
-        description: "C4: Enemy Dendro RES -20% during Shadow Dance",
+        description: desc!("C4: Enemy Dendro RES -20% during Shadow Dance"),
         stat: BuffableStat::ElementalResReduction(Element::Dendro),
         base_value: 0.20,
         scales_with_talent: false,
@@ -131,7 +131,7 @@ static NEFER_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "nefer_c2_em",
-        description: "C2: EM +200 at 5 Veil stacks",
+        description: desc!("C2: EM +200 at 5 Veil stacks"),
         stat: BuffableStat::ElementalMastery,
         base_value: 200.0,
         scales_with_talent: false,
@@ -145,7 +145,7 @@ static NEFER_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "nefer_c4_dendro_res_shred",
-        description: "C4: Opponents' Dendro RES -20% in Shadow Dance state",
+        description: desc!("C4: Opponents' Dendro RES -20% in Shadow Dance state"),
         stat: BuffableStat::ElementalResReduction(Element::Dendro),
         base_value: 0.20,
         scales_with_talent: false,
@@ -159,7 +159,7 @@ static NEFER_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "nefer_c6_lunar_bloom_dmg",
-        description: "C6: Party Lunar-Bloom DMG +15% at Ascendant Gleam",
+        description: desc!("C6: Party Lunar-Bloom DMG +15% at Ascendant Gleam"),
         stat: BuffableStat::TransformativeBonus,
         base_value: 0.15,
         scales_with_talent: false,
@@ -179,7 +179,7 @@ static NEFER_BUFFS: &[TalentBuffDef] = &[
 static TRAVELER_DENDRO_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Verdant Luxury",
-        description: "Characters within Lea Lotus Lamp field gain EM+60",
+        description: desc!("Characters within Lea Lotus Lamp field gain EM+60"),
         stat: BuffableStat::ElementalMastery,
         base_value: 60.0,
         scales_with_talent: false,
@@ -193,7 +193,7 @@ static TRAVELER_DENDRO_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "traveler_dendro_c6_dendro_dmg",
-        description: "C6: Party Dendro DMG Bonus +12% inside Lamp",
+        description: desc!("C6: Party Dendro DMG Bonus +12% inside Lamp"),
         stat: BuffableStat::ElementalDmgBonus(Element::Dendro),
         base_value: 0.12,
         scales_with_talent: false,
@@ -215,7 +215,7 @@ static TRAVELER_DENDRO_BUFFS: &[TalentBuffDef] = &[
 static ALHAITHAM_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Four-Causal Correction DMG Bonus",
-        description: "A4: DMG +0.1% per point of EM, max +100%",
+        description: desc!("A4: DMG +0.1% per point of EM, max +100%"),
         stat: BuffableStat::DmgBonus,
         base_value: 0.001,
         scales_with_talent: false,
@@ -229,7 +229,7 @@ static ALHAITHAM_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Chisel-Light Mirror EM Bonus",
-        description: "C2: EM +50 per Chisel-Light Mirror (max 3 mirrors)",
+        description: desc!("C2: EM +50 per Chisel-Light Mirror (max 3 mirrors)"),
         stat: BuffableStat::ElementalMastery,
         base_value: 50.0,
         scales_with_talent: false,
@@ -243,7 +243,7 @@ static ALHAITHAM_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Insight Team EM Bonus",
-        description: "C4: Team EM +120 while 3 Chisel-Light Mirrors are active",
+        description: desc!("C4: Team EM +120 while 3 Chisel-Light Mirrors are active"),
         stat: BuffableStat::ElementalMastery,
         base_value: 120.0,
         scales_with_talent: false,
@@ -257,7 +257,7 @@ static ALHAITHAM_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Structuring Crit Rate Bonus",
-        description: "C6: CR +10% (Toggle)",
+        description: desc!("C6: CR +10% (Toggle)"),
         stat: BuffableStat::CritRate,
         base_value: 0.10,
         scales_with_talent: false,
@@ -271,7 +271,7 @@ static ALHAITHAM_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Structuring Crit DMG Bonus",
-        description: "C6: CD +70% (Toggle)",
+        description: desc!("C6: CD +70% (Toggle)"),
         stat: BuffableStat::CritDmg,
         base_value: 0.70,
         scales_with_talent: false,
@@ -292,7 +292,7 @@ static ALHAITHAM_BUFFS: &[TalentBuffDef] = &[
 static BAIZHU_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Five Fortunes Forever Reaction DMG",
-        description: "A4: Reaction DMG bonus scales with HP (~2% per 1000 HP), max +50%",
+        description: desc!("A4: Reaction DMG bonus scales with HP (~2% per 1000 HP), max +50%"),
         stat: BuffableStat::TransformativeBonus,
         base_value: 0.00002,
         scales_with_talent: false,
@@ -306,7 +306,7 @@ static BAIZHU_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Ancient Art of Perception EM Bonus",
-        description: "C4: Team EM +80",
+        description: desc!("C4: Team EM +80"),
         stat: BuffableStat::ElementalMastery,
         base_value: 80.0,
         scales_with_talent: false,
@@ -320,7 +320,7 @@ static BAIZHU_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "baizhu_c4_em",
-        description: "C4: Party EM +80 after Burst",
+        description: desc!("C4: Party EM +80 after Burst"),
         stat: BuffableStat::ElementalMastery,
         base_value: 80.0,
         scales_with_talent: false,
@@ -334,7 +334,7 @@ static BAIZHU_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "baizhu_c6_skill_flat_dmg",
-        description: "C6: Skill DMG bonus based on 8% of Max HP",
+        description: desc!("C6: Skill DMG bonus based on 8% of Max HP"),
         stat: BuffableStat::SkillFlatDmg,
         base_value: 0.08,
         scales_with_talent: false,
@@ -353,7 +353,7 @@ static BAIZHU_BUFFS: &[TalentBuffDef] = &[
 static COLLEI_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Floral Sidewinder EM Bonus",
-        description: "C4: Party gains EM+60 while inside Cuilein-Anbar field",
+        description: desc!("C4: Party gains EM+60 while inside Cuilein-Anbar field"),
         stat: BuffableStat::ElementalMastery,
         base_value: 60.0,
         scales_with_talent: false,
@@ -367,7 +367,7 @@ static COLLEI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "collei_c4_em",
-        description: "C4: Party EM +60 after Burst (excludes self)",
+        description: desc!("C4: Party EM +60 after Burst (excludes self)"),
         stat: BuffableStat::ElementalMastery,
         base_value: 60.0,
         scales_with_talent: false,
@@ -388,7 +388,7 @@ static COLLEI_BUFFS: &[TalentBuffDef] = &[
 static EMILIE_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Rectification DMG Bonus",
-        description: "A4: DMG +0.1% per ATK, max +36%",
+        description: desc!("A4: DMG +0.1% per ATK, max +36%"),
         stat: BuffableStat::DmgBonus,
         base_value: 0.001,
         scales_with_talent: false,
@@ -402,7 +402,7 @@ static EMILIE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Consequence of Karma Skill DMG Bonus",
-        description: "C1: Elemental Skill DMG +20%",
+        description: desc!("C1: Elemental Skill DMG +20%"),
         stat: BuffableStat::SkillDmgBonus,
         base_value: 0.20,
         scales_with_talent: false,
@@ -416,7 +416,7 @@ static EMILIE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "The Controlled Blaze Dendro RES Down",
-        description: "C2: Enemy Dendro RES -30%",
+        description: desc!("C2: Enemy Dendro RES -30%"),
         stat: BuffableStat::ElementalResReduction(Element::Dendro),
         base_value: 0.30,
         scales_with_talent: false,
@@ -437,7 +437,7 @@ static EMILIE_BUFFS: &[TalentBuffDef] = &[
 static KAVEH_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "An Architect's Undertaking EM Bonus",
-        description: "A4: EM +25 per Bloom core consumed (max 4 stacks)",
+        description: desc!("A4: EM +25 per Bloom core consumed (max 4 stacks)"),
         stat: BuffableStat::ElementalMastery,
         base_value: 25.0,
         scales_with_talent: false,
@@ -451,7 +451,7 @@ static KAVEH_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Sublime Salvo Healing Bonus",
-        description: "C1: Healing Bonus +25%",
+        description: desc!("C1: Healing Bonus +25%"),
         stat: BuffableStat::HealingBonus,
         base_value: 0.25,
         scales_with_talent: false,
@@ -465,7 +465,7 @@ static KAVEH_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Feast of Apadana Bloom DMG Bonus",
-        description: "C4: Bloom DMG +60% (Toggle)",
+        description: desc!("C4: Bloom DMG +60% (Toggle)"),
         stat: BuffableStat::TransformativeBonus,
         base_value: 0.60,
         scales_with_talent: false,
@@ -485,7 +485,7 @@ static KAVEH_BUFFS: &[TalentBuffDef] = &[
 static KINICH_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Parrot Squawks Dendro RES Down",
-        description: "C2: Enemy Dendro RES -30% (Toggle)",
+        description: desc!("C2: Enemy Dendro RES -30% (Toggle)"),
         stat: BuffableStat::ElementalResReduction(Element::Dendro),
         base_value: 0.30,
         scales_with_talent: false,
@@ -499,7 +499,7 @@ static KINICH_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Parrot Squawks DMG Bonus",
-        description: "C2: DMG +100% (Toggle)",
+        description: desc!("C2: DMG +100% (Toggle)"),
         stat: BuffableStat::DmgBonus,
         base_value: 1.00,
         scales_with_talent: false,
@@ -513,7 +513,7 @@ static KINICH_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Canopy Hunter Burst DMG Bonus",
-        description: "C4: Burst DMG +70%",
+        description: desc!("C4: Burst DMG +70%"),
         stat: BuffableStat::BurstDmgBonus,
         base_value: 0.70,
         scales_with_talent: false,
@@ -534,7 +534,7 @@ static KIRARA_BUFFS: &[TalentBuffDef] = &[
     // TODO: A4 "Kindred Spirit": HP → Skill/Burst DMG bonus (complex formula, skipped)
     TalentBuffDef {
         name: "Kindred of the Sinovamakara DMG Bonus",
-        description: "C6: Team All Element DMG +12%",
+        description: desc!("C6: Team All Element DMG +12%"),
         stat: BuffableStat::DmgBonus,
         base_value: 0.12,
         scales_with_talent: false,
@@ -548,7 +548,7 @@ static KIRARA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "kirara_c6_dmg_bonus",
-        description: "C6: All Elemental DMG +12% (approximation)",
+        description: desc!("C6: All Elemental DMG +12% (approximation)"),
         stat: BuffableStat::DmgBonus,
         base_value: 0.12,
         scales_with_talent: false,
@@ -571,7 +571,7 @@ static KIRARA_BUFFS: &[TalentBuffDef] = &[
 static TIGHNARI_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Keen Sight EM Bonus",
-        description: "A1: EM +50",
+        description: desc!("A1: EM +50"),
         stat: BuffableStat::ElementalMastery,
         base_value: 50.0,
         scales_with_talent: false,
@@ -585,7 +585,7 @@ static TIGHNARI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Scholarly Blade CA DMG Bonus",
-        description: "A4: Charged Attack DMG +0.06% per EM, max +60%",
+        description: desc!("A4: Charged Attack DMG +0.06% per EM, max +60%"),
         stat: BuffableStat::ChargedAtkDmgBonus,
         base_value: 0.0006,
         scales_with_talent: false,
@@ -599,7 +599,7 @@ static TIGHNARI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Scholarly Blade Burst DMG Bonus",
-        description: "A4: Burst DMG +0.06% per EM, max +60%",
+        description: desc!("A4: Burst DMG +0.06% per EM, max +60%"),
         stat: BuffableStat::BurstDmgBonus,
         base_value: 0.0006,
         scales_with_talent: false,
@@ -613,7 +613,7 @@ static TIGHNARI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Beginners' Luck CA Crit Rate",
-        description: "C1: Charged Attack CR +15%",
+        description: desc!("C1: Charged Attack CR +15%"),
         stat: BuffableStat::CritRate,
         base_value: 0.15,
         scales_with_talent: false,
@@ -627,7 +627,7 @@ static TIGHNARI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Ingenuity of the Smiths Dendro DMG Bonus",
-        description: "C2: Dendro DMG +20%",
+        description: desc!("C2: Dendro DMG +20%"),
         stat: BuffableStat::ElementalDmgBonus(Element::Dendro),
         base_value: 0.20,
         scales_with_talent: false,
@@ -641,7 +641,7 @@ static TIGHNARI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Fortuitous Arrival Team EM Bonus",
-        description: "C4: Team EM +60 (Toggle)",
+        description: desc!("C4: Team EM +60 (Toggle)"),
         stat: BuffableStat::ElementalMastery,
         base_value: 60.0,
         scales_with_talent: false,
@@ -661,7 +661,7 @@ static TIGHNARI_BUFFS: &[TalentBuffDef] = &[
 static YAOYAO_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Nutcracker Dendro DMG Bonus",
-        description: "C1: Dendro DMG +15%",
+        description: desc!("C1: Dendro DMG +15%"),
         stat: BuffableStat::ElementalDmgBonus(Element::Dendro),
         base_value: 0.15,
         scales_with_talent: false,
@@ -675,7 +675,7 @@ static YAOYAO_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Whitesun Wheel EM Bonus",
-        description: "C4: EM +0.08% per HP, max +120 EM",
+        description: desc!("C4: EM +0.08% per HP, max +120 EM"),
         stat: BuffableStat::ElementalMastery,
         base_value: 0.0008,
         scales_with_talent: false,
@@ -689,7 +689,7 @@ static YAOYAO_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "yaoyao_c1_dendro_dmg",
-        description: "C1: Party Dendro DMG Bonus +15% on radish explosion",
+        description: desc!("C1: Party Dendro DMG Bonus +15% on radish explosion"),
         stat: BuffableStat::ElementalDmgBonus(Element::Dendro),
         base_value: 0.15,
         scales_with_talent: false,
@@ -703,7 +703,7 @@ static YAOYAO_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "yaoyao_c4_em",
-        description: "C4: EM bonus based on 0.3% of Max HP (max 120)",
+        description: desc!("C4: EM bonus based on 0.3% of Max HP (max 120)"),
         stat: BuffableStat::ElementalMastery,
         base_value: 0.003,
         scales_with_talent: false,

--- a/crates/data/src/talent_buffs/electro.rs
+++ b/crates/data/src/talent_buffs/electro.rs
@@ -6,7 +6,7 @@ use super::*;
 static INEFFA_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Ineffa A4 EM Share",
-        description: "Grants EM equal to 6% of Ineffa's total ATK",
+        description: desc!("Grants EM equal to 6% of Ineffa's total ATK"),
         stat: BuffableStat::ElementalMastery,
         base_value: 0.06,
         scales_with_talent: false,
@@ -20,7 +20,7 @@ static INEFFA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "ineffa_c1_lunar_charged_dmg",
-        description: "C1: Party Lunar-Charged DMG +2.5% per 100 ATK (max +50%)",
+        description: desc!("C1: Party Lunar-Charged DMG +2.5% per 100 ATK (max +50%)"),
         stat: BuffableStat::TransformativeBonus,
         base_value: 0.025,
         scales_with_talent: false,
@@ -44,7 +44,7 @@ static SARA_ATK_SCALING: [f64; 15] = [
 static SARA_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Tengu Juurai ATK Bonus",
-        description: "ATK bonus based on Sara's Base ATK",
+        description: desc!("ATK bonus based on Sara's Base ATK"),
         stat: BuffableStat::AtkFlat,
         base_value: 0.0,
         scales_with_talent: true,
@@ -58,7 +58,9 @@ static SARA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Sin of Pride",
-        description: "Electro CRIT DMG +60% (approximated as generic CritDmg; Electro-only in game)",
+        description: desc!(
+            "Electro CRIT DMG +60% (approximated as generic CritDmg; Electro-only in game)"
+        ),
         stat: BuffableStat::CritDmg,
         base_value: 0.60,
         scales_with_talent: false,
@@ -76,7 +78,7 @@ static SARA_BUFFS: &[TalentBuffDef] = &[
 // A4 "Static Electricity Field": Enemies hit by burst have DEF -15% for 10s
 static LISA_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
     name: "Static Electricity Field",
-    description: "Enemies hit by Lightning Rose have DEF -15% for 10s",
+    description: desc!("Enemies hit by Lightning Rose have DEF -15% for 10s"),
     stat: BuffableStat::DefReduction,
     base_value: 0.15,
     scales_with_talent: false,
@@ -97,7 +99,7 @@ static LISA_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
 static FLINS_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Whispering Flame EM Bonus",
-        description: "A4: Flins gains EM equal to 8% of her total ATK (max 160)",
+        description: desc!("A4: Flins gains EM equal to 8% of her total ATK (max 160)"),
         stat: BuffableStat::ElementalMastery,
         base_value: 0.08,
         scales_with_talent: false,
@@ -111,7 +113,7 @@ static FLINS_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Night on Bald Mountain ATK Bonus",
-        description: "C4: Flins gains ATK +20%",
+        description: desc!("C4: Flins gains ATK +20%"),
         stat: BuffableStat::AtkPercent,
         base_value: 0.20,
         scales_with_talent: false,
@@ -126,7 +128,9 @@ static FLINS_BUFFS: &[TalentBuffDef] = &[
     // C4 also enhances A4: 8%→10% (+2% delta), cap 160→220 (+60 delta)
     TalentBuffDef {
         name: "Night on Bald Mountain A4 EM Enhancement",
-        description: "C4: A4 EM coefficient enhanced from 8% to 10% (delta +2%, cap raised to 220)",
+        description: desc!(
+            "C4: A4 EM coefficient enhanced from 8% to 10% (delta +2%, cap raised to 220)"
+        ),
         stat: BuffableStat::ElementalMastery,
         base_value: 0.02,
         scales_with_talent: false,
@@ -140,7 +144,7 @@ static FLINS_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "flins_c2_electro_res_shred",
-        description: "C2: Opponents' Electro RES -25% during Ascendant Gleam Moonsign",
+        description: desc!("C2: Opponents' Electro RES -25% during Ascendant Gleam Moonsign"),
         stat: BuffableStat::ElementalResReduction(Element::Electro),
         base_value: 0.25,
         scales_with_talent: false,
@@ -154,7 +158,7 @@ static FLINS_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "flins_c6_lunar_charged_self",
-        description: "C6: Flins's Lunar-Charged DMG +35%",
+        description: desc!("C6: Flins's Lunar-Charged DMG +35%"),
         stat: BuffableStat::TransformativeBonus,
         base_value: 0.35,
         scales_with_talent: false,
@@ -168,7 +172,7 @@ static FLINS_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "flins_c6_lunar_charged_team",
-        description: "C6: Party Lunar-Charged DMG +10% during Moonsign",
+        description: desc!("C6: Party Lunar-Charged DMG +10% during Moonsign"),
         stat: BuffableStat::TransformativeBonus,
         base_value: 0.10,
         scales_with_talent: false,
@@ -194,7 +198,9 @@ static RAIDEN_SKILL_BURST_BONUS_SCALING: [f64; 15] = [
 static RAIDEN_SHOGUN_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Eye of Stormy Judgment BurstDmgBonus",
-        description: "Skill: BurstDmgBonus coefficient per energy cost point (multiply by target burst cost)",
+        description: desc!(
+            "Skill: BurstDmgBonus coefficient per energy cost point (multiply by target burst cost)"
+        ),
         stat: BuffableStat::BurstDmgBonus,
         base_value: 0.0,
         scales_with_talent: true,
@@ -209,7 +215,7 @@ static RAIDEN_SHOGUN_BUFFS: &[TalentBuffDef] = &[
     // C2 "Steelbreaker": During Musou Isshin, ignore 60% of enemy DEF
     TalentBuffDef {
         name: "Steelbreaker DEF Ignore",
-        description: "C2: During Musou Isshin state, ignore 60% of enemy DEF",
+        description: desc!("C2: During Musou Isshin state, ignore 60% of enemy DEF"),
         stat: BuffableStat::DefIgnore,
         base_value: 0.60,
         scales_with_talent: false,
@@ -223,7 +229,9 @@ static RAIDEN_SHOGUN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Pledge of Propriety ATK Bonus",
-        description: "C4: After Musou Isshin ends, nearby party members gain ATK+30% for 10s",
+        description: desc!(
+            "C4: After Musou Isshin ends, nearby party members gain ATK+30% for 10s"
+        ),
         stat: BuffableStat::AtkPercent,
         base_value: 0.30,
         scales_with_talent: false,
@@ -243,7 +251,7 @@ static RAIDEN_SHOGUN_BUFFS: &[TalentBuffDef] = &[
 static BEIDOU_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Bane of Evil Electro RES Shred",
-        description: "C6: During Stormbreaker, enemies have Electro RES -15%",
+        description: desc!("C6: During Stormbreaker, enemies have Electro RES -15%"),
         stat: BuffableStat::ElementalResReduction(Element::Electro),
         base_value: 0.15,
         scales_with_talent: false,
@@ -257,7 +265,7 @@ static BEIDOU_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "beidou_c4_electro_dmg",
-        description: "C4: Normal ATK Electro DMG Bonus +20% on hit",
+        description: desc!("C4: Normal ATK Electro DMG Bonus +20% on hit"),
         stat: BuffableStat::ElementalDmgBonus(Element::Electro),
         base_value: 0.20,
         scales_with_talent: false,
@@ -286,7 +294,9 @@ static IANSAN_BURST_ATK_SCALING: [f64; 15] = [
 static IANSAN_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Three Principles AtkFlat",
-        description: "Burst: Party gains flat ATK = Iansan ATK × coefficient (scales with burst level)",
+        description: desc!(
+            "Burst: Party gains flat ATK = Iansan ATK × coefficient (scales with burst level)"
+        ),
         stat: BuffableStat::AtkFlat,
         base_value: 0.0,
         scales_with_talent: true,
@@ -300,7 +310,7 @@ static IANSAN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Enhanced Resistance Training ATK Bonus",
-        description: "A1: Iansan gains ATK +20% for 15s",
+        description: desc!("A1: Iansan gains ATK +20% for 15s"),
         stat: BuffableStat::AtkPercent,
         base_value: 0.20,
         scales_with_talent: false,
@@ -314,7 +324,7 @@ static IANSAN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "iansan_c2_atk",
-        description: "C2: Off-field grants active character ATK +30%",
+        description: desc!("C2: Off-field grants active character ATK +30%"),
         stat: BuffableStat::AtkPercent,
         base_value: 0.30,
         scales_with_talent: false,
@@ -328,7 +338,7 @@ static IANSAN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "iansan_c6_dmg_bonus",
-        description: "C6: Active character DMG Bonus +25% on Nightsoul overflow",
+        description: desc!("C6: Active character DMG Bonus +25% on Nightsoul overflow"),
         stat: BuffableStat::DmgBonus,
         base_value: 0.25,
         scales_with_talent: false,
@@ -349,7 +359,9 @@ static IANSAN_BUFFS: &[TalentBuffDef] = &[
 static CLORINDE_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Clorinde A1 Electro Flat DMG",
-        description: "A1: Normal Attack deals additional Electro DMG equal to 20% of ATK (per stack, max 1800)",
+        description: desc!(
+            "A1: Normal Attack deals additional Electro DMG equal to 20% of ATK (per stack, max 1800)"
+        ),
         stat: BuffableStat::NormalAtkFlatDmg,
         base_value: 0.20,
         scales_with_talent: false,
@@ -363,7 +375,7 @@ static CLORINDE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Clorinde A4 CRIT Rate Bonus",
-        description: "A4: CRIT Rate +10% while in Ominous Inscription state",
+        description: desc!("A4: CRIT Rate +10% while in Ominous Inscription state"),
         stat: BuffableStat::CritRate,
         base_value: 0.10,
         scales_with_talent: false,
@@ -377,7 +389,7 @@ static CLORINDE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Clorinde C6 CRIT Rate",
-        description: "C6: CRIT Rate +10%",
+        description: desc!("C6: CRIT Rate +10%"),
         stat: BuffableStat::CritRate,
         base_value: 0.10,
         scales_with_talent: false,
@@ -391,7 +403,7 @@ static CLORINDE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Clorinde C6 CRIT DMG",
-        description: "C6: CRIT DMG +70%",
+        description: desc!("C6: CRIT DMG +70%"),
         stat: BuffableStat::CritDmg,
         base_value: 0.70,
         scales_with_talent: false,
@@ -411,7 +423,9 @@ static CLORINDE_BUFFS: &[TalentBuffDef] = &[
 static CYNO_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Cyno A4 Normal Atk Flat DMG",
-        description: "A4: During Pactsworn Pathclearer, Normal Attacks deal additional DMG equal to 150% of EM",
+        description: desc!(
+            "A4: During Pactsworn Pathclearer, Normal Attacks deal additional DMG equal to 150% of EM"
+        ),
         stat: BuffableStat::NormalAtkFlatDmg,
         base_value: 1.50,
         scales_with_talent: false,
@@ -425,7 +439,9 @@ static CYNO_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Cyno A4 Skill Flat DMG",
-        description: "A4: During Pactsworn Pathclearer, Skill deals additional DMG equal to 250% of EM",
+        description: desc!(
+            "A4: During Pactsworn Pathclearer, Skill deals additional DMG equal to 250% of EM"
+        ),
         stat: BuffableStat::SkillFlatDmg,
         base_value: 2.50,
         scales_with_talent: false,
@@ -439,7 +455,7 @@ static CYNO_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Cyno C2 Electro DMG Bonus",
-        description: "C2: Electro DMG Bonus +10% per stack, max 5 stacks (50% total)",
+        description: desc!("C2: Electro DMG Bonus +10% per stack, max 5 stacks (50% total)"),
         stat: BuffableStat::ElementalDmgBonus(Element::Electro),
         base_value: 0.10,
         scales_with_talent: false,
@@ -460,7 +476,7 @@ static CYNO_BUFFS: &[TalentBuffDef] = &[
 static KEQING_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Keqing A4 CRIT Rate",
-        description: "A4: After using Starward Sword, CRIT Rate +15% for 8s",
+        description: desc!("A4: After using Starward Sword, CRIT Rate +15% for 8s"),
         stat: BuffableStat::CritRate,
         base_value: 0.15,
         scales_with_talent: false,
@@ -474,7 +490,7 @@ static KEQING_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Keqing A4 Energy Recharge",
-        description: "A4: After using Starward Sword, Energy Recharge +15% for 8s",
+        description: desc!("A4: After using Starward Sword, Energy Recharge +15% for 8s"),
         stat: BuffableStat::EnergyRecharge,
         base_value: 0.15,
         scales_with_talent: false,
@@ -488,7 +504,7 @@ static KEQING_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Keqing C4 ATK Bonus",
-        description: "C4: Triggering an Electro-related reaction grants ATK +25% for 10s",
+        description: desc!("C4: Triggering an Electro-related reaction grants ATK +25% for 10s"),
         stat: BuffableStat::AtkPercent,
         base_value: 0.25,
         scales_with_talent: false,
@@ -502,7 +518,9 @@ static KEQING_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Keqing C6 Electro DMG Bonus",
-        description: "C6: Electro DMG Bonus +6% per Electro-related reaction triggered, max 4 stacks (24% total)",
+        description: desc!(
+            "C6: Electro DMG Bonus +6% per Electro-related reaction triggered, max 4 stacks (24% total)"
+        ),
         stat: BuffableStat::ElementalDmgBonus(Element::Electro),
         base_value: 0.24,
         scales_with_talent: false,
@@ -523,7 +541,9 @@ static KEQING_BUFFS: &[TalentBuffDef] = &[
 static YAE_MIKO_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Yae Miko A4 Skill DMG Bonus",
-        description: "A4: Sesshou Sakura DMG increased by 0.15% for every point of Elemental Mastery",
+        description: desc!(
+            "A4: Sesshou Sakura DMG increased by 0.15% for every point of Elemental Mastery"
+        ),
         stat: BuffableStat::SkillDmgBonus,
         base_value: 0.0015,
         scales_with_talent: false,
@@ -537,7 +557,7 @@ static YAE_MIKO_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Yae Miko C4 Electro DMG Bonus",
-        description: "C4: All nearby party members' Electro DMG Bonus increased by 20%",
+        description: desc!("C4: All nearby party members' Electro DMG Bonus increased by 20%"),
         stat: BuffableStat::ElementalDmgBonus(Element::Electro),
         base_value: 0.20,
         scales_with_talent: false,
@@ -551,7 +571,7 @@ static YAE_MIKO_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "yae_miko_c6_def_ignore",
-        description: "C6: Sesshou Sakura attacks ignore 60% of opponents' DEF",
+        description: desc!("C6: Sesshou Sakura attacks ignore 60% of opponents' DEF"),
         stat: BuffableStat::DefIgnore,
         base_value: 0.60,
         scales_with_talent: false,
@@ -571,7 +591,7 @@ static YAE_MIKO_BUFFS: &[TalentBuffDef] = &[
 static DORI_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Dori C4 Healing Bonus",
-        description: "C4: When HP falls below 50%, Healing Bonus +50%",
+        description: desc!("C4: When HP falls below 50%, Healing Bonus +50%"),
         stat: BuffableStat::HealingBonus,
         base_value: 0.50,
         scales_with_talent: false,
@@ -585,7 +605,7 @@ static DORI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Dori C4 Energy Recharge",
-        description: "C4: When Energy falls below 50%, Energy Recharge +30%",
+        description: desc!("C4: When Energy falls below 50%, Energy Recharge +30%"),
         stat: BuffableStat::EnergyRecharge,
         base_value: 0.30,
         scales_with_talent: false,
@@ -606,7 +626,7 @@ static DORI_BUFFS: &[TalentBuffDef] = &[
 static KUKI_SHINOBU_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Kuki Shinobu A1 Healing Bonus",
-        description: "A1: When HP is at or below 50%, Healing Bonus +15%",
+        description: desc!("A1: When HP is at or below 50%, Healing Bonus +15%"),
         stat: BuffableStat::HealingBonus,
         base_value: 0.15,
         scales_with_talent: false,
@@ -620,7 +640,7 @@ static KUKI_SHINOBU_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Kuki Shinobu A4 Skill Flat DMG",
-        description: "A4: Sanctifying Ring deals additional DMG equal to 25% of Kuki's EM",
+        description: desc!("A4: Sanctifying Ring deals additional DMG equal to 25% of Kuki's EM"),
         stat: BuffableStat::SkillFlatDmg,
         base_value: 0.25,
         scales_with_talent: false,
@@ -634,7 +654,7 @@ static KUKI_SHINOBU_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Kuki Shinobu C6 Elemental Mastery",
-        description: "C6: Elemental Mastery +150 for 15s after using Elemental Skill",
+        description: desc!("C6: Elemental Mastery +150 for 15s after using Elemental Skill"),
         stat: BuffableStat::ElementalMastery,
         base_value: 150.0,
         scales_with_talent: false,
@@ -655,7 +675,9 @@ static KUKI_SHINOBU_BUFFS: &[TalentBuffDef] = &[
 static RAZOR_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Razor C1 DMG Bonus",
-        description: "C1: After picking up an Electro Sigil from Wolf's Instinct, DMG +10% for 8s",
+        description: desc!(
+            "C1: After picking up an Electro Sigil from Wolf's Instinct, DMG +10% for 8s"
+        ),
         stat: BuffableStat::DmgBonus,
         base_value: 0.10,
         scales_with_talent: false,
@@ -669,7 +691,7 @@ static RAZOR_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Razor C2 CRIT Rate vs Low HP",
-        description: "C2: CRIT Rate +10% against enemies with HP below 30%",
+        description: desc!("C2: CRIT Rate +10% against enemies with HP below 30%"),
         stat: BuffableStat::CritRate,
         base_value: 0.10,
         scales_with_talent: false,
@@ -692,7 +714,7 @@ static RAZOR_BUFFS: &[TalentBuffDef] = &[
 static SETHOS_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Sethos A4 Charged Atk Flat DMG",
-        description: "A4: Charged Attack deals additional DMG equal to 700% of EM",
+        description: desc!("A4: Charged Attack deals additional DMG equal to 700% of EM"),
         stat: BuffableStat::ChargedAtkFlatDmg,
         base_value: 7.00,
         scales_with_talent: false,
@@ -706,7 +728,7 @@ static SETHOS_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Sethos C1 CRIT Rate",
-        description: "C1: CRIT Rate +15% for Charged Attacks",
+        description: desc!("C1: CRIT Rate +15% for Charged Attacks"),
         stat: BuffableStat::CritRate,
         base_value: 0.15,
         scales_with_talent: false,
@@ -720,7 +742,7 @@ static SETHOS_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Sethos C2 Electro DMG Bonus",
-        description: "C2: Electro DMG Bonus +15% per stack, max 2 stacks (30% total)",
+        description: desc!("C2: Electro DMG Bonus +15% per stack, max 2 stacks (30% total)"),
         stat: BuffableStat::ElementalDmgBonus(Element::Electro),
         base_value: 0.15,
         scales_with_talent: false,
@@ -734,7 +756,7 @@ static SETHOS_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Sethos C4 Team Elemental Mastery",
-        description: "C4: All nearby party members gain EM +80",
+        description: desc!("C4: All nearby party members gain EM +80"),
         stat: BuffableStat::ElementalMastery,
         base_value: 80.0,
         scales_with_talent: false,
@@ -755,7 +777,9 @@ static SETHOS_BUFFS: &[TalentBuffDef] = &[
 static VARESA_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Varesa A1 Plunging Atk Flat DMG",
-        description: "A1: Plunging Attack deals additional DMG equal to 180% of ATK (max value)",
+        description: desc!(
+            "A1: Plunging Attack deals additional DMG equal to 180% of ATK (max value)"
+        ),
         stat: BuffableStat::PlungingAtkFlatDmg,
         base_value: 1.80,
         scales_with_talent: false,
@@ -769,7 +793,7 @@ static VARESA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Varesa A4 ATK Bonus",
-        description: "A4: ATK +35% per stack, max 2 stacks (70% total)",
+        description: desc!("A4: ATK +35% per stack, max 2 stacks (70% total)"),
         stat: BuffableStat::AtkPercent,
         base_value: 0.35,
         scales_with_talent: false,
@@ -783,7 +807,7 @@ static VARESA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Varesa C6 CRIT Rate",
-        description: "C6: CRIT Rate +10%",
+        description: desc!("C6: CRIT Rate +10%"),
         stat: BuffableStat::CritRate,
         base_value: 0.10,
         scales_with_talent: false,
@@ -797,7 +821,7 @@ static VARESA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Varesa C6 CRIT DMG",
-        description: "C6: CRIT DMG +100%",
+        description: desc!("C6: CRIT DMG +100%"),
         stat: BuffableStat::CritDmg,
         base_value: 1.00,
         scales_with_talent: false,
@@ -817,7 +841,7 @@ static VARESA_BUFFS: &[TalentBuffDef] = &[
 static ORORON_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Ororon C2 Electro DMG Bonus",
-        description: "C2: Electro DMG Bonus +40% (max value)",
+        description: desc!("C2: Electro DMG Bonus +40% (max value)"),
         stat: BuffableStat::ElementalDmgBonus(Element::Electro),
         base_value: 0.40,
         scales_with_talent: false,
@@ -831,7 +855,9 @@ static ORORON_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Ororon C6 Team ATK Bonus",
-        description: "C6: Active character gains ATK +10% per stack, max 3 stacks (30% total)",
+        description: desc!(
+            "C6: Active character gains ATK +10% per stack, max 3 stacks (30% total)"
+        ),
         stat: BuffableStat::AtkPercent,
         base_value: 0.10,
         scales_with_talent: false,

--- a/crates/data/src/talent_buffs/geo.rs
+++ b/crates/data/src/talent_buffs/geo.rs
@@ -8,7 +8,7 @@ use super::*;
 static ALBEDO_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Homuncular Nature",
-        description: "After burst, grants EM+125 to nearby party members for 10s",
+        description: desc!("After burst, grants EM+125 to nearby party members for 10s"),
         stat: BuffableStat::ElementalMastery,
         base_value: 125.0,
         scales_with_talent: false,
@@ -22,7 +22,7 @@ static ALBEDO_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "albedo_c1_def",
-        description: "C1: DEF +50% on Skill use",
+        description: desc!("C1: DEF +50% on Skill use"),
         stat: BuffableStat::DefPercent,
         base_value: 0.50,
         scales_with_talent: false,
@@ -36,7 +36,7 @@ static ALBEDO_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "albedo_c4_plunging_dmg",
-        description: "C4: Plunging ATK DMG +30% in Solar Isotoma",
+        description: desc!("C4: Plunging ATK DMG +30% in Solar Isotoma"),
         stat: BuffableStat::PlungingAtkDmgBonus,
         base_value: 0.30,
         scales_with_talent: false,
@@ -50,7 +50,7 @@ static ALBEDO_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "albedo_c6_dmg_bonus",
-        description: "C6: DMG Bonus +17% with Crystallize shield",
+        description: desc!("C6: DMG Bonus +17% with Crystallize shield"),
         stat: BuffableStat::DmgBonus,
         base_value: 0.17,
         scales_with_talent: false,
@@ -74,7 +74,7 @@ static GOROU_SKILL_DEF_SCALING: [f64; 15] = [
 static GOROU_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Inuzaka All-Round Defense",
-        description: "DEF increase based on skill talent level",
+        description: desc!("DEF increase based on skill talent level"),
         stat: BuffableStat::DefFlat,
         base_value: 0.0,
         scales_with_talent: true,
@@ -88,7 +88,9 @@ static GOROU_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Inuzaka All-Round Defense - Geo DMG",
-        description: "With 3 Geo members, Geo DMG Bonus +15% (approximation: always registered)",
+        description: desc!(
+            "With 3 Geo members, Geo DMG Bonus +15% (approximation: always registered)"
+        ),
         stat: BuffableStat::ElementalDmgBonus(Element::Geo),
         base_value: 0.15,
         scales_with_talent: false,
@@ -102,7 +104,7 @@ static GOROU_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "gorou_c6_geo_crit_dmg",
-        description: "C6: Geo CRIT DMG +40% at Crunch",
+        description: desc!("C6: Geo CRIT DMG +40% at Crunch"),
         stat: BuffableStat::CritDmg,
         base_value: 0.40,
         scales_with_talent: false,
@@ -120,7 +122,7 @@ static GOROU_BUFFS: &[TalentBuffDef] = &[
 // A4 passive "Strategic Reserve": Geo DMG+12% when passing through Jade Screen
 static NINGGUANG_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
     name: "Strategic Reserve",
-    description: "Characters passing through Jade Screen gain Geo DMG Bonus +12%",
+    description: desc!("Characters passing through Jade Screen gain Geo DMG Bonus +12%"),
     stat: BuffableStat::ElementalDmgBonus(Element::Geo),
     base_value: 0.12,
     scales_with_talent: false,
@@ -145,7 +147,7 @@ static YUN_JIN_BURST_SCALING: [f64; 15] = [
 static YUN_JIN_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Cliffbreaker's Banner Normal ATK Bonus",
-        description: "Normal Attack DMG increased based on Yun Jin's DEF",
+        description: desc!("Normal Attack DMG increased based on Yun Jin's DEF"),
         stat: BuffableStat::NormalAtkFlatDmg,
         base_value: 0.0,
         scales_with_talent: true,
@@ -159,7 +161,7 @@ static YUN_JIN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "yun_jin_c2_normal_dmg",
-        description: "C2: Normal ATK DMG +15% after Burst",
+        description: desc!("C2: Normal ATK DMG +15% after Burst"),
         stat: BuffableStat::NormalAtkDmgBonus,
         base_value: 0.15,
         scales_with_talent: false,
@@ -173,7 +175,7 @@ static YUN_JIN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "yun_jin_c4_def",
-        description: "C4: DEF +20% on Crystallize",
+        description: desc!("C4: DEF +20% on Crystallize"),
         stat: BuffableStat::DefPercent,
         base_value: 0.20,
         scales_with_talent: false,
@@ -192,7 +194,7 @@ static YUN_JIN_BUFFS: &[TalentBuffDef] = &[
 static ZHONGLI_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Jade Shield Pyro RES Shred",
-        description: "Nearby enemies' Pyro RES -20%",
+        description: desc!("Nearby enemies' Pyro RES -20%"),
         stat: BuffableStat::ElementalResReduction(Element::Pyro),
         base_value: 0.20,
         scales_with_talent: false,
@@ -206,7 +208,7 @@ static ZHONGLI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Jade Shield Hydro RES Shred",
-        description: "Nearby enemies' Hydro RES -20%",
+        description: desc!("Nearby enemies' Hydro RES -20%"),
         stat: BuffableStat::ElementalResReduction(Element::Hydro),
         base_value: 0.20,
         scales_with_talent: false,
@@ -220,7 +222,7 @@ static ZHONGLI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Jade Shield Electro RES Shred",
-        description: "Nearby enemies' Electro RES -20%",
+        description: desc!("Nearby enemies' Electro RES -20%"),
         stat: BuffableStat::ElementalResReduction(Element::Electro),
         base_value: 0.20,
         scales_with_talent: false,
@@ -234,7 +236,7 @@ static ZHONGLI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Jade Shield Cryo RES Shred",
-        description: "Nearby enemies' Cryo RES -20%",
+        description: desc!("Nearby enemies' Cryo RES -20%"),
         stat: BuffableStat::ElementalResReduction(Element::Cryo),
         base_value: 0.20,
         scales_with_talent: false,
@@ -248,7 +250,7 @@ static ZHONGLI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Jade Shield Dendro RES Shred",
-        description: "Nearby enemies' Dendro RES -20%",
+        description: desc!("Nearby enemies' Dendro RES -20%"),
         stat: BuffableStat::ElementalResReduction(Element::Dendro),
         base_value: 0.20,
         scales_with_talent: false,
@@ -262,7 +264,7 @@ static ZHONGLI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Jade Shield Anemo RES Shred",
-        description: "Nearby enemies' Anemo RES -20%",
+        description: desc!("Nearby enemies' Anemo RES -20%"),
         stat: BuffableStat::ElementalResReduction(Element::Anemo),
         base_value: 0.20,
         scales_with_talent: false,
@@ -276,7 +278,7 @@ static ZHONGLI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Jade Shield Geo RES Shred",
-        description: "Nearby enemies' Geo RES -20%",
+        description: desc!("Nearby enemies' Geo RES -20%"),
         stat: BuffableStat::ElementalResReduction(Element::Geo),
         base_value: 0.20,
         scales_with_talent: false,
@@ -290,7 +292,7 @@ static ZHONGLI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Jade Shield Physical RES Shred",
-        description: "Nearby enemies' Physical RES -20%",
+        description: desc!("Nearby enemies' Physical RES -20%"),
         stat: BuffableStat::PhysicalResReduction,
         base_value: 0.20,
         scales_with_talent: false,
@@ -309,7 +311,7 @@ static ZHONGLI_BUFFS: &[TalentBuffDef] = &[
 // Lunar-Crystallize Reaction DMG +30% for nearby party members
 static ZIBAI_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
     name: "At Birth Are Souls Born C2 Reaction DMG",
-    description: "C2: Lunar-Crystallize Reaction DMG +30% for nearby party members",
+    description: desc!("C2: Lunar-Crystallize Reaction DMG +30% for nearby party members"),
     stat: BuffableStat::TransformativeBonus,
     base_value: 0.30,
     scales_with_talent: false,
@@ -337,7 +339,7 @@ static ILLUGA_BUFFS: &[TalentBuffDef] = &[
     // A1 "Torchforger's Covenant": After Geo DMG hits, party CRIT/EM buff
     TalentBuffDef {
         name: "Torchforger's Covenant - CRIT Rate",
-        description: "A1: After Geo DMG hits opponent, party CRIT Rate +5% for 20s",
+        description: desc!("A1: After Geo DMG hits opponent, party CRIT Rate +5% for 20s"),
         stat: BuffableStat::CritRate,
         base_value: 0.05,
         scales_with_talent: false,
@@ -351,7 +353,7 @@ static ILLUGA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Torchforger's Covenant - CRIT DMG",
-        description: "A1: After Geo DMG hits opponent, party CRIT DMG +10% for 20s",
+        description: desc!("A1: After Geo DMG hits opponent, party CRIT DMG +10% for 20s"),
         stat: BuffableStat::CritDmg,
         base_value: 0.10,
         scales_with_talent: false,
@@ -365,7 +367,7 @@ static ILLUGA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Torchforger's Covenant - EM (Moonsign)",
-        description: "A1: With Moonsign active, party EM +50 for 20s",
+        description: desc!("A1: With Moonsign active, party EM +50 for 20s"),
         stat: BuffableStat::ElementalMastery,
         base_value: 50.0,
         scales_with_talent: false,
@@ -384,7 +386,7 @@ static ILLUGA_BUFFS: &[TalentBuffDef] = &[
     // C4 "Unfolding of Starlight": Party DEF +200 during Burst
     TalentBuffDef {
         name: "illuga_c4_def_flat",
-        description: "C4: Party DEF +200 during Burst",
+        description: desc!("C4: Party DEF +200 during Burst"),
         stat: BuffableStat::DefFlat,
         base_value: 200.0,
         scales_with_talent: false,
@@ -399,7 +401,7 @@ static ILLUGA_BUFFS: &[TalentBuffDef] = &[
     // C6 "Nightmare Orioles": Enhances A1 values
     TalentBuffDef {
         name: "Nightmare Orioles - CRIT Rate",
-        description: "C6: A1 CRIT Rate enhanced to +10%",
+        description: desc!("C6: A1 CRIT Rate enhanced to +10%"),
         stat: BuffableStat::CritRate,
         base_value: 0.05,
         scales_with_talent: false,
@@ -413,7 +415,7 @@ static ILLUGA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Nightmare Orioles - CRIT DMG",
-        description: "C6: A1 CRIT DMG enhanced to +30%",
+        description: desc!("C6: A1 CRIT DMG enhanced to +30%"),
         stat: BuffableStat::CritDmg,
         base_value: 0.20,
         scales_with_talent: false,
@@ -427,7 +429,7 @@ static ILLUGA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Nightmare Orioles - EM",
-        description: "C6: A1 EM enhanced to +80",
+        description: desc!("C6: A1 EM enhanced to +80"),
         stat: BuffableStat::ElementalMastery,
         base_value: 30.0,
         scales_with_talent: false,
@@ -453,7 +455,7 @@ static XILONEN_BUFFS: &[TalentBuffDef] = &[
     // Geo is always active; up to 3 Geo Samplers convert to Pyro/Hydro/Cryo/Electro per party members.
     TalentBuffDef {
         name: "Yohual's Scratch Geo RES Reduction",
-        description: "Skill: Geo Sampler reduces nearby enemy Geo RES (always active)",
+        description: desc!("Skill: Geo Sampler reduces nearby enemy Geo RES (always active)"),
         stat: BuffableStat::ElementalResReduction(Element::Geo),
         base_value: 0.0,
         scales_with_talent: true,
@@ -467,7 +469,9 @@ static XILONEN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Yohual's Scratch Pyro RES Reduction",
-        description: "Skill: Pyro Sampler reduces nearby enemy Pyro RES (if Pyro party member present)",
+        description: desc!(
+            "Skill: Pyro Sampler reduces nearby enemy Pyro RES (if Pyro party member present)"
+        ),
         stat: BuffableStat::ElementalResReduction(Element::Pyro),
         base_value: 0.0,
         scales_with_talent: true,
@@ -481,7 +485,9 @@ static XILONEN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Yohual's Scratch Hydro RES Reduction",
-        description: "Skill: Hydro Sampler reduces nearby enemy Hydro RES (if Hydro party member present)",
+        description: desc!(
+            "Skill: Hydro Sampler reduces nearby enemy Hydro RES (if Hydro party member present)"
+        ),
         stat: BuffableStat::ElementalResReduction(Element::Hydro),
         base_value: 0.0,
         scales_with_talent: true,
@@ -495,7 +501,9 @@ static XILONEN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Yohual's Scratch Cryo RES Reduction",
-        description: "Skill: Cryo Sampler reduces nearby enemy Cryo RES (if Cryo party member present)",
+        description: desc!(
+            "Skill: Cryo Sampler reduces nearby enemy Cryo RES (if Cryo party member present)"
+        ),
         stat: BuffableStat::ElementalResReduction(Element::Cryo),
         base_value: 0.0,
         scales_with_talent: true,
@@ -509,7 +517,9 @@ static XILONEN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Yohual's Scratch Electro RES Reduction",
-        description: "Skill: Electro Sampler reduces nearby enemy Electro RES (if Electro party member present)",
+        description: desc!(
+            "Skill: Electro Sampler reduces nearby enemy Electro RES (if Electro party member present)"
+        ),
         stat: BuffableStat::ElementalResReduction(Element::Electro),
         base_value: 0.0,
         scales_with_talent: true,
@@ -526,7 +536,7 @@ static XILONEN_BUFFS: &[TalentBuffDef] = &[
     // Electro effect (energy restore + burst CD) is not a stat buff, omitted
     TalentBuffDef {
         name: "Chiucue Mix Geo DMG Bonus",
-        description: "C2: Geo Source Sample grants nearby active character Geo DMG +50%",
+        description: desc!("C2: Geo Source Sample grants nearby active character Geo DMG +50%"),
         stat: BuffableStat::ElementalDmgBonus(Element::Geo),
         base_value: 0.50,
         scales_with_talent: false,
@@ -540,7 +550,7 @@ static XILONEN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Chiucue Mix Pyro ATK Bonus",
-        description: "C2: Pyro Source Sample grants nearby active Pyro character ATK +45%",
+        description: desc!("C2: Pyro Source Sample grants nearby active Pyro character ATK +45%"),
         stat: BuffableStat::AtkPercent,
         base_value: 0.45,
         scales_with_talent: false,
@@ -554,7 +564,9 @@ static XILONEN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Chiucue Mix Hydro Max HP Bonus",
-        description: "C2: Hydro Source Sample grants nearby active Hydro character Max HP +45%",
+        description: desc!(
+            "C2: Hydro Source Sample grants nearby active Hydro character Max HP +45%"
+        ),
         stat: BuffableStat::HpPercent,
         base_value: 0.45,
         scales_with_talent: false,
@@ -568,7 +580,9 @@ static XILONEN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Chiucue Mix Cryo CRIT DMG Bonus",
-        description: "C2: Cryo Source Sample grants nearby active Cryo character CRIT DMG +60%",
+        description: desc!(
+            "C2: Cryo Source Sample grants nearby active Cryo character CRIT DMG +60%"
+        ),
         stat: BuffableStat::CritDmg,
         base_value: 0.60,
         scales_with_talent: false,
@@ -582,7 +596,9 @@ static XILONEN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Suchitl's Trance Normal ATK Flat DMG",
-        description: "C4: Normal, Charged, and Plunging Attacks deal additional DMG equal to 65% of Xilonen's DEF",
+        description: desc!(
+            "C4: Normal, Charged, and Plunging Attacks deal additional DMG equal to 65% of Xilonen's DEF"
+        ),
         stat: BuffableStat::NormalAtkFlatDmg,
         base_value: 0.65,
         scales_with_talent: false,
@@ -596,7 +612,9 @@ static XILONEN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Suchitl's Trance Charged ATK Flat DMG",
-        description: "C4: Normal, Charged, and Plunging Attacks deal additional DMG equal to 65% of Xilonen's DEF",
+        description: desc!(
+            "C4: Normal, Charged, and Plunging Attacks deal additional DMG equal to 65% of Xilonen's DEF"
+        ),
         stat: BuffableStat::ChargedAtkFlatDmg,
         base_value: 0.65,
         scales_with_talent: false,
@@ -610,7 +628,9 @@ static XILONEN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Suchitl's Trance Plunging ATK Flat DMG",
-        description: "C4: Normal, Charged, and Plunging Attacks deal additional DMG equal to 65% of Xilonen's DEF",
+        description: desc!(
+            "C4: Normal, Charged, and Plunging Attacks deal additional DMG equal to 65% of Xilonen's DEF"
+        ),
         stat: BuffableStat::PlungingAtkFlatDmg,
         base_value: 0.65,
         scales_with_talent: false,
@@ -628,7 +648,7 @@ static XILONEN_BUFFS: &[TalentBuffDef] = &[
 // C6 "A Guru's Inbred Nature": NA DMG +235% DEF as flat DMG
 static CHIORI_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
     name: "A Guru's Inbred Nature - NA Flat DMG",
-    description: "C6: Normal Attack DMG +235% of Chiori's DEF as flat DMG",
+    description: desc!("C6: Normal Attack DMG +235% of Chiori's DEF as flat DMG"),
     stat: BuffableStat::NormalAtkFlatDmg,
     base_value: 2.35,
     scales_with_talent: false,
@@ -648,7 +668,7 @@ static CHIORI_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
 static ITTO_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Bloodline of the Crimson Oni",
-        description: "A4: Arataki Kesagiri DMG +35% of Itto's DEF as flat DMG",
+        description: desc!("A4: Arataki Kesagiri DMG +35% of Itto's DEF as flat DMG"),
         stat: BuffableStat::ChargedAtkFlatDmg,
         base_value: 0.35,
         scales_with_talent: false,
@@ -662,7 +682,7 @@ static ITTO_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Alright More Dumplings DEF Bonus",
-        description: "C4: After Raging Oni King ends, team DEF +20%",
+        description: desc!("C4: After Raging Oni King ends, team DEF +20%"),
         stat: BuffableStat::DefPercent,
         base_value: 0.20,
         scales_with_talent: false,
@@ -676,7 +696,7 @@ static ITTO_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Alright More Dumplings ATK Bonus",
-        description: "C4: After Raging Oni King ends, team ATK +20%",
+        description: desc!("C4: After Raging Oni King ends, team ATK +20%"),
         stat: BuffableStat::AtkPercent,
         base_value: 0.20,
         scales_with_talent: false,
@@ -690,7 +710,7 @@ static ITTO_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Crimson Oni King's Legacy CA CRIT DMG",
-        description: "C6: Arataki Kesagiri CRIT DMG +70%",
+        description: desc!("C6: Arataki Kesagiri CRIT DMG +70%"),
         stat: BuffableStat::CritDmg,
         base_value: 0.70,
         scales_with_talent: false,
@@ -710,7 +730,7 @@ static ITTO_BUFFS: &[TalentBuffDef] = &[
 static KACHINA_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Flowy Mountain Geo DMG Bonus",
-        description: "A4: Geo DMG Bonus +20%",
+        description: desc!("A4: Geo DMG Bonus +20%"),
         stat: BuffableStat::ElementalDmgBonus(Element::Geo),
         base_value: 0.20,
         scales_with_talent: false,
@@ -724,7 +744,7 @@ static KACHINA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Stand Together DEF Bonus",
-        description: "C4: DEF +8~20% based on nearby enemies (max 20%)",
+        description: desc!("C4: DEF +8~20% based on nearby enemies (max 20%)"),
         stat: BuffableStat::DefPercent,
         base_value: 0.20,
         scales_with_talent: false,
@@ -746,7 +766,7 @@ static KACHINA_BUFFS: &[TalentBuffDef] = &[
 static NAVIA_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "That Shard's Ours - NA DMG Bonus",
-        description: "A1: After burst, Normal Attack DMG +40%",
+        description: desc!("A1: After burst, Normal Attack DMG +40%"),
         stat: BuffableStat::NormalAtkDmgBonus,
         base_value: 0.40,
         scales_with_talent: false,
@@ -760,7 +780,7 @@ static NAVIA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "That Shard's Ours - CA DMG Bonus",
-        description: "A1: After burst, Charged Attack DMG +40%",
+        description: desc!("A1: After burst, Charged Attack DMG +40%"),
         stat: BuffableStat::ChargedAtkDmgBonus,
         base_value: 0.40,
         scales_with_talent: false,
@@ -774,7 +794,7 @@ static NAVIA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "That Shard's Ours - Plunge DMG Bonus",
-        description: "A1: After burst, Plunging Attack DMG +40%",
+        description: desc!("A1: After burst, Plunging Attack DMG +40%"),
         stat: BuffableStat::PlungingAtkDmgBonus,
         base_value: 0.40,
         scales_with_talent: false,
@@ -788,7 +808,7 @@ static NAVIA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Turns Out She's a Damn Good Miner ATK Bonus",
-        description: "A4: ATK +20% per Shockwave stack (max +40%)",
+        description: desc!("A4: ATK +20% per Shockwave stack (max +40%)"),
         stat: BuffableStat::AtkPercent,
         base_value: 0.40,
         scales_with_talent: false,
@@ -802,7 +822,7 @@ static NAVIA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Candlelight CRIT Rate",
-        description: "C2: CRIT Rate +12% per Shockwave stack, up to 3 stacks (+36% max)",
+        description: desc!("C2: CRIT Rate +12% per Shockwave stack, up to 3 stacks (+36% max)"),
         stat: BuffableStat::CritRate,
         base_value: 0.12,
         scales_with_talent: false,
@@ -816,7 +836,7 @@ static NAVIA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "The Little Bit of Kindness Geo RES Reduction",
-        description: "C4: Enemy Geo RES -20%",
+        description: desc!("C4: Enemy Geo RES -20%"),
         stat: BuffableStat::ElementalResReduction(Element::Geo),
         base_value: 0.20,
         scales_with_talent: false,
@@ -836,7 +856,7 @@ static NAVIA_BUFFS: &[TalentBuffDef] = &[
 static NOELLE_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Combat Maid CA DMG Bonus",
-        description: "C2: Charged Attack DMG +15%",
+        description: desc!("C2: Charged Attack DMG +15%"),
         stat: BuffableStat::ChargedAtkDmgBonus,
         base_value: 0.15,
         scales_with_talent: false,
@@ -850,7 +870,7 @@ static NOELLE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Must Be Spotless ATK Flat",
-        description: "C6: During burst, ATK +50% of Noelle's DEF as flat ATK",
+        description: desc!("C6: During burst, ATK +50% of Noelle's DEF as flat ATK"),
         stat: BuffableStat::AtkFlat,
         base_value: 0.50,
         scales_with_talent: false,

--- a/crates/data/src/talent_buffs/hydro.rs
+++ b/crates/data/src/talent_buffs/hydro.rs
@@ -7,7 +7,7 @@ use super::*;
 static AINO_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Aino C1 EM Share",
-        description: "After Skill or Burst, Aino and active character gain EM+80 for 15s",
+        description: desc!("After Skill or Burst, Aino and active character gain EM+80 for 15s"),
         stat: BuffableStat::ElementalMastery,
         base_value: 80.0,
         scales_with_talent: false,
@@ -21,7 +21,7 @@ static AINO_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Aino A4 Burst DMG from EM",
-        description: "Burst DMG increased by 50% of Elemental Mastery",
+        description: desc!("Burst DMG increased by 50% of Elemental Mastery"),
         stat: BuffableStat::BurstFlatDmg,
         base_value: 0.50,
         scales_with_talent: false,
@@ -42,7 +42,7 @@ static AINO_BUFFS: &[TalentBuffDef] = &[
 // C2 "Vitality Burst": Hydro DMG+15% during skill
 static BARBARA_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
     name: "Vitality Burst",
-    description: "During skill, active character gains Hydro DMG Bonus +15%",
+    description: desc!("During skill, active character gains Hydro DMG Bonus +15%"),
     stat: BuffableStat::ElementalDmgBonus(Element::Hydro),
     base_value: 0.15,
     scales_with_talent: false,
@@ -65,7 +65,7 @@ static CANDACE_BURST_NORMAL_SCALING: [f64; 15] = [
 static CANDACE_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Sacred Rite: Heron's Sanctum",
-        description: "Normal ATK DMG Bonus based on burst talent level",
+        description: desc!("Normal ATK DMG Bonus based on burst talent level"),
         stat: BuffableStat::NormalAtkDmgBonus,
         base_value: 0.0,
         scales_with_talent: true,
@@ -79,7 +79,7 @@ static CANDACE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "candace_c2_hp",
-        description: "C2: Max HP +20% for 15s when Skill hits",
+        description: desc!("C2: Max HP +20% for 15s when Skill hits"),
         stat: BuffableStat::HpPercent,
         base_value: 0.20,
         scales_with_talent: false,
@@ -112,7 +112,7 @@ static FURINA_BURST_C1_BONUS: [f64; 15] = [
 static FURINA_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Let the People Rejoice DMG Bonus (C0 300pt)",
-        description: "Max fanfare (300pt) DMG bonus based on burst talent level",
+        description: desc!("Max fanfare (300pt) DMG bonus based on burst talent level"),
         stat: BuffableStat::DmgBonus,
         base_value: 0.0,
         scales_with_talent: true,
@@ -126,7 +126,7 @@ static FURINA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Let the People Rejoice DMG Bonus (C1+ extra 100pt)",
-        description: "C1 extra fanfare (+100pt) DMG bonus based on burst talent level",
+        description: desc!("C1 extra fanfare (+100pt) DMG bonus based on burst talent level"),
         stat: BuffableStat::DmgBonus,
         base_value: 0.0,
         scales_with_talent: true,
@@ -153,7 +153,7 @@ static MONA_BURST_DMG_SCALING: [f64; 15] = [
 static MONA_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Stellaris Phantasm DMG Bonus",
-        description: "Omen increases DMG taken by opponents",
+        description: desc!("Omen increases DMG taken by opponents"),
         stat: BuffableStat::DmgBonus,
         base_value: 0.0,
         scales_with_talent: true,
@@ -167,7 +167,7 @@ static MONA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "mona_c1_reaction_dmg",
-        description: "C1: Reaction DMG +15% vs Omen-affected opponents",
+        description: desc!("C1: Reaction DMG +15% vs Omen-affected opponents"),
         stat: BuffableStat::TransformativeBonus,
         base_value: 0.15,
         scales_with_talent: false,
@@ -181,7 +181,7 @@ static MONA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "mona_c2_em",
-        description: "C2: Party EM +80 on Charged ATK hit",
+        description: desc!("C2: Party EM +80 on Charged ATK hit"),
         stat: BuffableStat::ElementalMastery,
         base_value: 80.0,
         scales_with_talent: false,
@@ -195,7 +195,7 @@ static MONA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "mona_c4_crit_rate",
-        description: "C4: CRIT Rate +15% vs Omen-affected opponents",
+        description: desc!("C4: CRIT Rate +15% vs Omen-affected opponents"),
         stat: BuffableStat::CritRate,
         base_value: 0.15,
         scales_with_talent: false,
@@ -209,7 +209,7 @@ static MONA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "mona_c4_crit_dmg",
-        description: "C4: CRIT DMG +15% vs Omen-affected opponents (approximation)",
+        description: desc!("C4: CRIT DMG +15% vs Omen-affected opponents (approximation)"),
         stat: BuffableStat::CritDmg,
         base_value: 0.15,
         scales_with_talent: false,
@@ -223,7 +223,7 @@ static MONA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "mona_c6_charged_dmg",
-        description: "C6: Charged ATK DMG +180% (max in Illusory Torrent)",
+        description: desc!("C6: Charged ATK DMG +180% (max in Illusory Torrent)"),
         stat: BuffableStat::ChargedAtkDmgBonus,
         base_value: 1.80,
         scales_with_talent: false,
@@ -247,7 +247,7 @@ static MONA_BUFFS: &[TalentBuffDef] = &[
 static NILOU_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Dreaming Dance of the Lotuslight",
-        description: "HP30000超過1000ごとにBloom DMG+9%、最大+400%",
+        description: desc!("HP30000超過1000ごとにBloom DMG+9%、最大+400%"),
         stat: BuffableStat::TransformativeBonus,
         base_value: 0.0, // HP-dependent special formula (scaling_value == 0.0 triggers it)
         scales_with_talent: false,
@@ -261,7 +261,7 @@ static NILOU_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "nilou_c2_hydro_res_shred",
-        description: "C2: Opponents' Hydro RES -35% after Hydro DMG",
+        description: desc!("C2: Opponents' Hydro RES -35% after Hydro DMG"),
         stat: BuffableStat::ElementalResReduction(Element::Hydro),
         base_value: 0.35,
         scales_with_talent: false,
@@ -275,7 +275,7 @@ static NILOU_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "nilou_c2_dendro_res_shred",
-        description: "C2: Opponents' Dendro RES -35% after Bloom DMG",
+        description: desc!("C2: Opponents' Dendro RES -35% after Bloom DMG"),
         stat: BuffableStat::ElementalResReduction(Element::Dendro),
         base_value: 0.35,
         scales_with_talent: false,
@@ -289,7 +289,7 @@ static NILOU_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "nilou_c4_burst_dmg",
-        description: "C4: Dance of Abzendegi DMG +50% after 3rd dance step",
+        description: desc!("C4: Dance of Abzendegi DMG +50% after 3rd dance step"),
         stat: BuffableStat::BurstDmgBonus,
         base_value: 0.50,
         scales_with_talent: false,
@@ -303,7 +303,7 @@ static NILOU_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "nilou_c6_crit_rate",
-        description: "C6: CRIT Rate +0.6% per 1000 Max HP (max +30%)",
+        description: desc!("C6: CRIT Rate +0.6% per 1000 Max HP (max +30%)"),
         stat: BuffableStat::CritRate,
         base_value: 0.006,
         scales_with_talent: false,
@@ -317,7 +317,7 @@ static NILOU_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "nilou_c6_crit_dmg",
-        description: "C6: CRIT DMG +1.2% per 1000 Max HP (max +60%)",
+        description: desc!("C6: CRIT DMG +1.2% per 1000 Max HP (max +60%)"),
         stat: BuffableStat::CritDmg,
         base_value: 0.012,
         scales_with_talent: false,
@@ -337,7 +337,7 @@ static NILOU_BUFFS: &[TalentBuffDef] = &[
 static YELAN_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Adapt With Ease",
-        description: "DMG Bonus ramps up to max value 0.50",
+        description: desc!("DMG Bonus ramps up to max value 0.50"),
         stat: BuffableStat::DmgBonus,
         base_value: 0.50,
         scales_with_talent: false,
@@ -351,7 +351,7 @@ static YELAN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "yelan_c4_hp",
-        description: "C4: Party Max HP +10% per marked opponent (max 4)",
+        description: desc!("C4: Party Max HP +10% per marked opponent (max 4)"),
         stat: BuffableStat::HpPercent,
         base_value: 0.10,
         scales_with_talent: false,
@@ -373,7 +373,7 @@ static YELAN_BUFFS: &[TalentBuffDef] = &[
 static COLUMBINA_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Columbina C1 Lunar Reaction DMG",
-        description: "C1: Lunar Reaction DMG +1.5%",
+        description: desc!("C1: Lunar Reaction DMG +1.5%"),
         stat: BuffableStat::TransformativeBonus,
         base_value: 0.015,
         scales_with_talent: false,
@@ -387,7 +387,7 @@ static COLUMBINA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Columbina C2 Lunar Brilliance HP",
-        description: "C2: Lunar Brilliance — Columbina HP +40% for 8s (self only)",
+        description: desc!("C2: Lunar Brilliance — Columbina HP +40% for 8s (self only)"),
         stat: BuffableStat::HpPercent,
         base_value: 0.40,
         scales_with_talent: false,
@@ -401,7 +401,7 @@ static COLUMBINA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Columbina C2 Lunar Reaction DMG",
-        description: "C2: Lunar Reaction DMG +7%",
+        description: desc!("C2: Lunar Reaction DMG +7%"),
         stat: BuffableStat::TransformativeBonus,
         base_value: 0.07,
         scales_with_talent: false,
@@ -415,7 +415,7 @@ static COLUMBINA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Columbina C3 Lunar Reaction DMG",
-        description: "C3: Lunar Reaction DMG +1.5%",
+        description: desc!("C3: Lunar Reaction DMG +1.5%"),
         stat: BuffableStat::TransformativeBonus,
         base_value: 0.015,
         scales_with_talent: false,
@@ -429,7 +429,7 @@ static COLUMBINA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Columbina C4 Lunar Reaction DMG",
-        description: "C4: Lunar Reaction DMG +1.5%",
+        description: desc!("C4: Lunar Reaction DMG +1.5%"),
         stat: BuffableStat::TransformativeBonus,
         base_value: 0.015,
         scales_with_talent: false,
@@ -443,7 +443,7 @@ static COLUMBINA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Columbina C5 Lunar Reaction DMG",
-        description: "C5: Lunar Reaction DMG +1.5%",
+        description: desc!("C5: Lunar Reaction DMG +1.5%"),
         stat: BuffableStat::TransformativeBonus,
         base_value: 0.015,
         scales_with_talent: false,
@@ -457,7 +457,9 @@ static COLUMBINA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Columbina C6 Elemental CritDMG",
-        description: "After Lunar reaction in domain, corresponding element CritDMG +80% for 8s",
+        description: desc!(
+            "After Lunar reaction in domain, corresponding element CritDMG +80% for 8s"
+        ),
         stat: BuffableStat::CritDmg,
         base_value: 0.80,
         scales_with_talent: false,
@@ -471,7 +473,7 @@ static COLUMBINA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Columbina C6 Lunar Reaction DMG",
-        description: "C6: Lunar Reaction DMG +7%",
+        description: desc!("C6: Lunar Reaction DMG +7%"),
         stat: BuffableStat::TransformativeBonus,
         base_value: 0.07,
         scales_with_talent: false,
@@ -495,7 +497,7 @@ static COLUMBINA_BUFFS: &[TalentBuffDef] = &[
 static AYATO_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Namisen Max Stacks NA DMG Bonus",
-        description: "A1: Namisen at max stacks grants NA DMG Bonus +56% (approximated max)",
+        description: desc!("A1: Namisen at max stacks grants NA DMG Bonus +56% (approximated max)"),
         stat: BuffableStat::NormalAtkDmgBonus,
         base_value: 0.56,
         scales_with_talent: false,
@@ -509,7 +511,7 @@ static AYATO_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Kyouka Fuushi Shunsuiken DMG",
-        description: "C1: Shunsuiken DMG +40% (approximated as Normal ATK DMG Bonus)",
+        description: desc!("C1: Shunsuiken DMG +40% (approximated as Normal ATK DMG Bonus)"),
         stat: BuffableStat::NormalAtkDmgBonus,
         base_value: 0.40,
         scales_with_talent: false,
@@ -523,7 +525,7 @@ static AYATO_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "World Source Max HP",
-        description: "C2: Max HP +50%",
+        description: desc!("C2: Max HP +50%"),
         stat: BuffableStat::HpPercent,
         base_value: 0.50,
         scales_with_talent: false,
@@ -545,7 +547,7 @@ static AYATO_BUFFS: &[TalentBuffDef] = &[
 //   TODO: C6 ATK SPD buff not implementable (no AtkSpd BuffableStat)
 static DAHLIA_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
     name: "Petal Rain Shield Strength",
-    description: "C2: Shield Strength +25%",
+    description: desc!("C2: Shield Strength +25%"),
     stat: BuffableStat::ShieldStrength,
     base_value: 0.25,
     scales_with_talent: false,
@@ -567,7 +569,7 @@ static DAHLIA_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
 // C6 "Tamanooya's Casket": Hydro DMG +40% during Burst when NA/CA hit
 static KOKOMI_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
     name: "Tamanooya's Casket Hydro DMG",
-    description: "C6: Hydro DMG Bonus +40% during Burst when Normal/Charged Attacks hit",
+    description: desc!("C6: Hydro DMG Bonus +40% during Burst when Normal/Charged Attacks hit"),
     stat: BuffableStat::ElementalDmgBonus(Element::Hydro),
     base_value: 0.40,
     scales_with_talent: false,
@@ -586,7 +588,7 @@ static KOKOMI_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
 // C4 "Sharky's Pal": Burst DMG +75%
 static MUALANI_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
     name: "Sharky's Pal Burst DMG",
-    description: "C4: Elemental Burst DMG +75%",
+    description: desc!("C4: Elemental Burst DMG +75%"),
     stat: BuffableStat::BurstDmgBonus,
     base_value: 0.75,
     scales_with_talent: false,
@@ -606,7 +608,7 @@ static MUALANI_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
 static NEUVILLETTE_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Tidal Affinity CA DMG Bonus",
-        description: "A1: CA DMG Bonus at 3 Sourcewater Droplets (max value +60%)",
+        description: desc!("A1: CA DMG Bonus at 3 Sourcewater Droplets (max value +60%)"),
         stat: BuffableStat::ChargedAtkDmgBonus,
         base_value: 0.60,
         scales_with_talent: false,
@@ -620,7 +622,7 @@ static NEUVILLETTE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Heir to the Ancient Sea's Authority Hydro DMG",
-        description: "A4: Hydro DMG Bonus +30% when HP conditions are met",
+        description: desc!("A4: Hydro DMG Bonus +30% when HP conditions are met"),
         stat: BuffableStat::ElementalDmgBonus(Element::Hydro),
         base_value: 0.30,
         scales_with_talent: false,
@@ -634,7 +636,7 @@ static NEUVILLETTE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "The Law's Final Remains CRIT DMG",
-        description: "C2: CRIT DMG +14% per stack, max 3 stacks (+42%)",
+        description: desc!("C2: CRIT DMG +14% per stack, max 3 stacks (+42%)"),
         stat: BuffableStat::CritDmg,
         base_value: 0.14,
         scales_with_talent: false,
@@ -657,7 +659,7 @@ static NEUVILLETTE_BUFFS: &[TalentBuffDef] = &[
 static SIGEWINNE_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "A Friendly Rivalry Hydro DMG",
-        description: "A1: After Skill, team Hydro DMG Bonus +8%",
+        description: desc!("A1: After Skill, team Hydro DMG Bonus +8%"),
         stat: BuffableStat::ElementalDmgBonus(Element::Hydro),
         base_value: 0.08,
         scales_with_talent: false,
@@ -671,7 +673,7 @@ static SIGEWINNE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Targeted Treatment Hydro RES Shred",
-        description: "C2: Enemy Hydro RES -35%",
+        description: desc!("C2: Enemy Hydro RES -35%"),
         stat: BuffableStat::ElementalResReduction(Element::Hydro),
         base_value: 0.35,
         scales_with_talent: false,
@@ -685,7 +687,7 @@ static SIGEWINNE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Whirlpool Wisdom CRIT Rate",
-        description: "C6: CRIT Rate +20% (max value from HP scaling)",
+        description: desc!("C6: CRIT Rate +20% (max value from HP scaling)"),
         stat: BuffableStat::CritRate,
         base_value: 0.20,
         scales_with_talent: false,
@@ -699,7 +701,7 @@ static SIGEWINNE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Whirlpool Wisdom CRIT DMG",
-        description: "C6: CRIT DMG +110% (max value from HP scaling)",
+        description: desc!("C6: CRIT DMG +110% (max value from HP scaling)"),
         stat: BuffableStat::CritDmg,
         base_value: 1.10,
         scales_with_talent: false,
@@ -719,7 +721,7 @@ static SIGEWINNE_BUFFS: &[TalentBuffDef] = &[
 static XINGQIU_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Rainbow Upon the Azure Sky Hydro RES Shred",
-        description: "C2: Enemies hit by Rain Swords have Hydro RES -15% for 4s",
+        description: desc!("C2: Enemies hit by Rain Swords have Hydro RES -15% for 4s"),
         stat: BuffableStat::ElementalResReduction(Element::Hydro),
         base_value: 0.15,
         scales_with_talent: false,
@@ -733,7 +735,7 @@ static XINGQIU_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "xingqiu_c4_skill_dmg",
-        description: "C4: Skill DMG +50% during Burst",
+        description: desc!("C4: Skill DMG +50% during Burst"),
         stat: BuffableStat::SkillDmgBonus,
         base_value: 0.50,
         scales_with_talent: false,

--- a/crates/data/src/talent_buffs/pyro.rs
+++ b/crates/data/src/talent_buffs/pyro.rs
@@ -10,7 +10,9 @@ static BENNETT_BURST_ATK_SCALING: [f64; 15] = [
 static BENNETT_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Fantastic Voyage ATK Bonus",
-        description: "Characters within the burst field gain ATK bonus based on Bennett's Base ATK",
+        description: desc!(
+            "Characters within the burst field gain ATK bonus based on Bennett's Base ATK"
+        ),
         stat: BuffableStat::AtkFlat,
         base_value: 0.0,
         scales_with_talent: true,
@@ -25,7 +27,9 @@ static BENNETT_BUFFS: &[TalentBuffDef] = &[
     // C1 "Grand Expectation": +20% of Base ATK added to Fantastic Voyage ATK bonus
     TalentBuffDef {
         name: "Grand Expectation",
-        description: "C1: Fantastic Voyage ATK bonus gains additional 20% of Bennett's Base ATK",
+        description: desc!(
+            "C1: Fantastic Voyage ATK bonus gains additional 20% of Bennett's Base ATK"
+        ),
         stat: BuffableStat::AtkFlat,
         base_value: 0.20,
         scales_with_talent: false,
@@ -39,7 +43,7 @@ static BENNETT_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Spirit of Pyro",
-        description: "C6: Characters within the burst field gain Pyro DMG Bonus +15%",
+        description: desc!("C6: Characters within the burst field gain Pyro DMG Bonus +15%"),
         stat: BuffableStat::ElementalDmgBonus(Element::Pyro),
         base_value: 0.15,
         scales_with_talent: false,
@@ -57,7 +61,7 @@ static BENNETT_BUFFS: &[TalentBuffDef] = &[
 // C6 "Wildfire": ATK+15% for party during burst
 static AMBER_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
     name: "Wildfire",
-    description: "During burst, party members gain ATK+15%",
+    description: desc!("During burst, party members gain ATK+15%"),
     stat: BuffableStat::AtkPercent,
     base_value: 0.15,
     scales_with_talent: false,
@@ -76,7 +80,9 @@ static AMBER_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
 static CHEVREUSE_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Vanguard's Coordinated Tactics",
-        description: "After Overloaded, ATK+20% for party (Pyro+Electro teams only, approximation)",
+        description: desc!(
+            "After Overloaded, ATK+20% for party (Pyro+Electro teams only, approximation)"
+        ),
         stat: BuffableStat::AtkPercent,
         base_value: 0.20,
         scales_with_talent: false,
@@ -93,7 +99,7 @@ static CHEVREUSE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Overloaded Pyro RES Shred",
-        description: "After Overloaded reaction, enemy Pyro RES -40% for 6s",
+        description: desc!("After Overloaded reaction, enemy Pyro RES -40% for 6s"),
         stat: BuffableStat::ElementalResReduction(Element::Pyro),
         base_value: 0.40,
         scales_with_talent: false,
@@ -107,7 +113,7 @@ static CHEVREUSE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Overloaded Electro RES Shred",
-        description: "After Overloaded reaction, enemy Electro RES -40% for 6s",
+        description: desc!("After Overloaded reaction, enemy Electro RES -40% for 6s"),
         stat: BuffableStat::ElementalResReduction(Element::Electro),
         base_value: 0.40,
         scales_with_talent: false,
@@ -121,7 +127,7 @@ static CHEVREUSE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "chevreuse_c6_pyro_dmg",
-        description: "C6: Party Pyro DMG Bonus +20% per stack (max 3)",
+        description: desc!("C6: Party Pyro DMG Bonus +20% per stack (max 3)"),
         stat: BuffableStat::ElementalDmgBonus(Element::Pyro),
         base_value: 0.20,
         scales_with_talent: false,
@@ -135,7 +141,7 @@ static CHEVREUSE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "chevreuse_c6_electro_dmg",
-        description: "C6: Party Electro DMG Bonus +20% per stack (max 3)",
+        description: desc!("C6: Party Electro DMG Bonus +20% per stack (max 3)"),
         stat: BuffableStat::ElementalDmgBonus(Element::Electro),
         base_value: 0.20,
         scales_with_talent: false,
@@ -154,7 +160,7 @@ static CHEVREUSE_BUFFS: &[TalentBuffDef] = &[
 static THOMA_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Burning Heart - Normal ATK",
-        description: "After burst, party Normal ATK DMG +15%",
+        description: desc!("After burst, party Normal ATK DMG +15%"),
         stat: BuffableStat::NormalAtkDmgBonus,
         base_value: 0.15,
         scales_with_talent: false,
@@ -168,7 +174,7 @@ static THOMA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Burning Heart - Charged ATK",
-        description: "After burst, party Charged ATK DMG +15%",
+        description: desc!("After burst, party Charged ATK DMG +15%"),
         stat: BuffableStat::ChargedAtkDmgBonus,
         base_value: 0.15,
         scales_with_talent: false,
@@ -182,7 +188,7 @@ static THOMA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Burning Heart - Plunging ATK",
-        description: "After burst, party Plunging ATK DMG +15%",
+        description: desc!("After burst, party Plunging ATK DMG +15%"),
         stat: BuffableStat::PlungingAtkDmgBonus,
         base_value: 0.15,
         scales_with_talent: false,
@@ -203,7 +209,9 @@ static THOMA_BUFFS: &[TalentBuffDef] = &[
 static YOIMIYA_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Summer Night's Dawn",
-        description: "After burst, party members (excluding Yoimiya) gain ATK+20% (max assumption)",
+        description: desc!(
+            "After burst, party members (excluding Yoimiya) gain ATK+20% (max assumption)"
+        ),
         stat: BuffableStat::AtkPercent,
         base_value: 0.20,
         scales_with_talent: false,
@@ -218,7 +226,7 @@ static YOIMIYA_BUFFS: &[TalentBuffDef] = &[
     // C1: ATK +20% on Aurous Blaze defeat
     TalentBuffDef {
         name: "yoimiya_c1_atk",
-        description: "C1: ATK +20% for 20s when Aurous Blaze-affected opponent defeated",
+        description: desc!("C1: ATK +20% for 20s when Aurous Blaze-affected opponent defeated"),
         stat: BuffableStat::AtkPercent,
         base_value: 0.20,
         scales_with_talent: false,
@@ -233,7 +241,7 @@ static YOIMIYA_BUFFS: &[TalentBuffDef] = &[
     // C2: Pyro DMG +25% on Pyro CRIT
     TalentBuffDef {
         name: "yoimiya_c2_pyro_dmg",
-        description: "C2: Pyro DMG Bonus +25% for 6s on Pyro CRIT hit",
+        description: desc!("C2: Pyro DMG Bonus +25% for 6s on Pyro CRIT hit"),
         stat: BuffableStat::ElementalDmgBonus(Element::Pyro),
         base_value: 0.25,
         scales_with_talent: false,
@@ -256,7 +264,9 @@ static YOIMIYA_BUFFS: &[TalentBuffDef] = &[
 static DURIN_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Light Manifest (Purity) Pyro RES Down",
-        description: "A1: Enemy Pyro RES -20% after Burning/Overloaded/Pyro Swirl/Pyro Crystallize",
+        description: desc!(
+            "A1: Enemy Pyro RES -20% after Burning/Overloaded/Pyro Swirl/Pyro Crystallize"
+        ),
         stat: BuffableStat::ElementalResReduction(Element::Pyro),
         base_value: 0.20,
         scales_with_talent: false,
@@ -270,7 +280,7 @@ static DURIN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Light Manifest (Darkness) Amplifying Bonus",
-        description: "A1: Vaporize/Melt DMG +40% in Darkness form",
+        description: desc!("A1: Vaporize/Melt DMG +40% in Darkness form"),
         stat: BuffableStat::AmplifyingBonus,
         base_value: 0.40,
         scales_with_talent: false,
@@ -284,7 +294,7 @@ static DURIN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Unground Visions Pyro DMG Bonus",
-        description: "C2: Pyro DMG +50% for party after triggering reactions",
+        description: desc!("C2: Pyro DMG +50% for party after triggering reactions"),
         stat: BuffableStat::ElementalDmgBonus(Element::Pyro),
         base_value: 0.50,
         scales_with_talent: false,
@@ -298,7 +308,7 @@ static DURIN_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Emanare's Source Burst DMG Bonus",
-        description: "C4: Elemental Burst DMG +40%",
+        description: desc!("C4: Elemental Burst DMG +40%"),
         stat: BuffableStat::BurstDmgBonus,
         base_value: 0.40,
         scales_with_talent: false,
@@ -313,7 +323,7 @@ static DURIN_BUFFS: &[TalentBuffDef] = &[
     // C4 "Emanare's Source": Burst DMG +40% (conditional toggle)
     TalentBuffDef {
         name: "durin_c4_burst_dmg",
-        description: "C4: Elemental Burst DMG +40%",
+        description: desc!("C4: Elemental Burst DMG +40%"),
         stat: BuffableStat::BurstDmgBonus,
         base_value: 0.40,
         scales_with_talent: false,
@@ -328,7 +338,7 @@ static DURIN_BUFFS: &[TalentBuffDef] = &[
     // C6: DEF Ignore 30%
     TalentBuffDef {
         name: "durin_c6_def_ignore",
-        description: "C6: Burst DMG ignores 30% of opponents' DEF",
+        description: desc!("C6: Burst DMG ignores 30% of opponents' DEF"),
         stat: BuffableStat::DefIgnore,
         base_value: 0.30,
         scales_with_talent: false,
@@ -343,7 +353,7 @@ static DURIN_BUFFS: &[TalentBuffDef] = &[
     // C6: DEF Reduction 30% (Light form)
     TalentBuffDef {
         name: "durin_c6_def_reduction",
-        description: "C6: Light form decreases opponent DEF by 30%",
+        description: desc!("C6: Light form decreases opponent DEF by 30%"),
         stat: BuffableStat::DefReduction,
         base_value: 0.30,
         scales_with_talent: false,
@@ -363,7 +373,7 @@ static DURIN_BUFFS: &[TalentBuffDef] = &[
 static KLEE_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Explosive Frags DEF Reduction",
-        description: "C2: Enemies hit by Jumpy Dumpty mines have DEF -23%",
+        description: desc!("C2: Enemies hit by Jumpy Dumpty mines have DEF -23%"),
         stat: BuffableStat::DefReduction,
         base_value: 0.23,
         scales_with_talent: false,
@@ -377,7 +387,7 @@ static KLEE_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Blazing Delight Pyro DMG Bonus",
-        description: "C6: During Sparks 'n' Splash, party gains Pyro DMG +10%",
+        description: desc!("C6: During Sparks 'n' Splash, party gains Pyro DMG +10%"),
         stat: BuffableStat::ElementalDmgBonus(Element::Pyro),
         base_value: 0.10,
         scales_with_talent: false,
@@ -392,7 +402,7 @@ static KLEE_BUFFS: &[TalentBuffDef] = &[
     // C2: Mine DEF reduction 23% (conditional toggle)
     TalentBuffDef {
         name: "klee_c2_def_reduction",
-        description: "C2: Jumpy Dumpty mines reduce opponent DEF by 23%",
+        description: desc!("C2: Jumpy Dumpty mines reduce opponent DEF by 23%"),
         stat: BuffableStat::DefReduction,
         base_value: 0.23,
         scales_with_talent: false,
@@ -407,7 +417,7 @@ static KLEE_BUFFS: &[TalentBuffDef] = &[
     // C6: Party Pyro DMG +10% (conditional toggle)
     TalentBuffDef {
         name: "klee_c6_pyro_dmg",
-        description: "C6: Sparks 'n' Splash grants party Pyro DMG Bonus +10%",
+        description: desc!("C6: Sparks 'n' Splash grants party Pyro DMG Bonus +10%"),
         stat: BuffableStat::ElementalDmgBonus(Element::Pyro),
         base_value: 0.10,
         scales_with_talent: false,
@@ -428,7 +438,7 @@ static MAVUIKA_BUFFS: &[TalentBuffDef] = &[
     // C2 "The Ashen Price": Ring of Searing Radiance form reduces nearby enemies' DEF -20%
     TalentBuffDef {
         name: "The Ashen Price DEF Reduction",
-        description: "C2: In Ring of Searing Radiance form, nearby enemies' DEF -20%",
+        description: desc!("C2: In Ring of Searing Radiance form, nearby enemies' DEF -20%"),
         stat: BuffableStat::DefReduction,
         base_value: 0.20,
         scales_with_talent: false,
@@ -442,7 +452,7 @@ static MAVUIKA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Sunfrost Encomium ATK Bonus",
-        description: "A1: Mavuika's own ATK+30% while in Nightsoul's Blessing state",
+        description: desc!("A1: Mavuika's own ATK+30% while in Nightsoul's Blessing state"),
         stat: BuffableStat::AtkPercent,
         base_value: 0.30,
         scales_with_talent: false,
@@ -456,7 +466,9 @@ static MAVUIKA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Fire-Forged Heritage DMG Bonus",
-        description: "A4: DMG Bonus from Fighting Spirit consumed (max +40% at C0/200pt, adopting max value)",
+        description: desc!(
+            "A4: DMG Bonus from Fighting Spirit consumed (max +40% at C0/200pt, adopting max value)"
+        ),
         stat: BuffableStat::DmgBonus,
         base_value: 0.40,
         scales_with_talent: false,
@@ -477,7 +489,7 @@ static MAVUIKA_BUFFS: &[TalentBuffDef] = &[
 static ARLECCHINO_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Crimson Flower Pyro DMG Bonus",
-        description: "A1: Arlecchino gains Pyro DMG Bonus +40%",
+        description: desc!("A1: Arlecchino gains Pyro DMG Bonus +40%"),
         stat: BuffableStat::ElementalDmgBonus(Element::Pyro),
         base_value: 0.40,
         scales_with_talent: false,
@@ -492,7 +504,7 @@ static ARLECCHINO_BUFFS: &[TalentBuffDef] = &[
     // TODO: A4 "The Balemoon Alone May Know" — ATK scales into All RES reduction; complex, not implemented
     TalentBuffDef {
         name: "Foul Legacy CRIT Rate Bonus",
-        description: "C6: CRIT Rate +10%",
+        description: desc!("C6: CRIT Rate +10%"),
         stat: BuffableStat::CritRate,
         base_value: 0.10,
         scales_with_talent: false,
@@ -506,7 +518,7 @@ static ARLECCHINO_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Foul Legacy CRIT DMG Bonus",
-        description: "C6: CRIT DMG +70%",
+        description: desc!("C6: CRIT DMG +70%"),
         stat: BuffableStat::CritDmg,
         base_value: 0.70,
         scales_with_talent: false,
@@ -527,7 +539,7 @@ static ARLECCHINO_BUFFS: &[TalentBuffDef] = &[
 static DEHYA_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "The Flame Incandescent HP Bonus",
-        description: "C1: Dehya's Max HP +20%",
+        description: desc!("C1: Dehya's Max HP +20%"),
         stat: BuffableStat::HpPercent,
         base_value: 0.20,
         scales_with_talent: false,
@@ -541,7 +553,7 @@ static DEHYA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "The Sand-Blanketed Fortress Skill DMG Bonus",
-        description: "C2: Skill DMG +50%",
+        description: desc!("C2: Skill DMG +50%"),
         stat: BuffableStat::SkillDmgBonus,
         base_value: 0.50,
         scales_with_talent: false,
@@ -555,7 +567,7 @@ static DEHYA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "The Burning Claws Cleave CRIT Rate Bonus",
-        description: "C6: CRIT Rate +10% (max value)",
+        description: desc!("C6: CRIT Rate +10% (max value)"),
         stat: BuffableStat::CritRate,
         base_value: 0.10,
         scales_with_talent: false,
@@ -569,7 +581,7 @@ static DEHYA_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "The Burning Claws Cleave CRIT DMG Bonus",
-        description: "C6: CRIT DMG +60% (max value)",
+        description: desc!("C6: CRIT DMG +60% (max value)"),
         stat: BuffableStat::CritDmg,
         base_value: 0.60,
         scales_with_talent: false,
@@ -592,7 +604,7 @@ static DEHYA_BUFFS: &[TalentBuffDef] = &[
 static DILUC_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Flowing Flame Pyro DMG Bonus",
-        description: "A4: After using Elemental Skill, Pyro DMG +20%",
+        description: desc!("A4: After using Elemental Skill, Pyro DMG +20%"),
         stat: BuffableStat::ElementalDmgBonus(Element::Pyro),
         base_value: 0.20,
         scales_with_talent: false,
@@ -606,7 +618,7 @@ static DILUC_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Conviction DMG Bonus",
-        description: "C1: DMG +15% when enemy HP is above 50%",
+        description: desc!("C1: DMG +15% when enemy HP is above 50%"),
         stat: BuffableStat::DmgBonus,
         base_value: 0.15,
         scales_with_talent: false,
@@ -620,7 +632,7 @@ static DILUC_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Searing Ember ATK Bonus",
-        description: "C2: ATK +10% per stack, max 3 stacks",
+        description: desc!("C2: ATK +10% per stack, max 3 stacks"),
         stat: BuffableStat::AtkPercent,
         base_value: 0.10,
         scales_with_talent: false,
@@ -634,7 +646,7 @@ static DILUC_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Flowing Ember Skill DMG Bonus",
-        description: "C4: After skill combo, Skill DMG +40%",
+        description: desc!("C4: After skill combo, Skill DMG +40%"),
         stat: BuffableStat::SkillDmgBonus,
         base_value: 0.40,
         scales_with_talent: false,
@@ -648,7 +660,7 @@ static DILUC_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Flaming Sword Normal ATK DMG Bonus",
-        description: "C6: Normal ATK DMG +30% during burst",
+        description: desc!("C6: Normal ATK DMG +30% during burst"),
         stat: BuffableStat::NormalAtkDmgBonus,
         base_value: 0.30,
         scales_with_talent: false,
@@ -669,7 +681,7 @@ static DILUC_BUFFS: &[TalentBuffDef] = &[
 static GAMING_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Dance of Amity Plunging ATK DMG Bonus",
-        description: "A4: Plunging ATK DMG +20% when HP is 50% or above",
+        description: desc!("A4: Plunging ATK DMG +20% when HP is 50% or above"),
         stat: BuffableStat::PlungingAtkDmgBonus,
         base_value: 0.20,
         scales_with_talent: false,
@@ -683,7 +695,7 @@ static GAMING_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Savage Hunting Fangs ATK Bonus",
-        description: "C2: ATK +20%",
+        description: desc!("C2: ATK +20%"),
         stat: BuffableStat::AtkPercent,
         base_value: 0.20,
         scales_with_talent: false,
@@ -697,7 +709,7 @@ static GAMING_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Dance of Auspicious Crane CRIT Rate Bonus",
-        description: "C6: CRIT Rate +20%",
+        description: desc!("C6: CRIT Rate +20%"),
         stat: BuffableStat::CritRate,
         base_value: 0.20,
         scales_with_talent: false,
@@ -711,7 +723,7 @@ static GAMING_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Dance of Auspicious Crane CRIT DMG Bonus",
-        description: "C6: CRIT DMG +40%",
+        description: desc!("C6: CRIT DMG +40%"),
         stat: BuffableStat::CritDmg,
         base_value: 0.40,
         scales_with_talent: false,
@@ -732,7 +744,9 @@ static GAMING_BUFFS: &[TalentBuffDef] = &[
 static HU_TAO_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Flutter By CRIT Rate Bonus",
-        description: "A1: After Paramita Papilio ends, party members (excl. Hu Tao) gain CRIT Rate +12%",
+        description: desc!(
+            "A1: After Paramita Papilio ends, party members (excl. Hu Tao) gain CRIT Rate +12%"
+        ),
         stat: BuffableStat::CritRate,
         base_value: 0.12,
         scales_with_talent: false,
@@ -746,7 +760,7 @@ static HU_TAO_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Sanguine Rouge Pyro DMG Bonus",
-        description: "A4: When HP is 50% or lower, Pyro DMG Bonus +33%",
+        description: desc!("A4: When HP is 50% or lower, Pyro DMG Bonus +33%"),
         stat: BuffableStat::ElementalDmgBonus(Element::Pyro),
         base_value: 0.33,
         scales_with_talent: false,
@@ -760,7 +774,9 @@ static HU_TAO_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Garden of Eternal Rest",
-        description: "C4: After defeating Blood Blossom enemy, party (excl. Hu Tao) CRIT Rate +12% for 15s",
+        description: desc!(
+            "C4: After defeating Blood Blossom enemy, party (excl. Hu Tao) CRIT Rate +12% for 15s"
+        ),
         stat: BuffableStat::CritRate,
         base_value: 0.12,
         scales_with_talent: false,
@@ -780,7 +796,7 @@ static HU_TAO_BUFFS: &[TalentBuffDef] = &[
 static XIANGLING_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Crispy Outside Pyro RES Shred",
-        description: "C1: Enemies hit by Guoba have Pyro RES -15% for 6s",
+        description: desc!("C1: Enemies hit by Guoba have Pyro RES -15% for 6s"),
         stat: BuffableStat::ElementalResReduction(Element::Pyro),
         base_value: 0.15,
         scales_with_talent: false,
@@ -794,7 +810,7 @@ static XIANGLING_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Condensed Pyronado Pyro DMG Bonus",
-        description: "C6: During Pyronado, party gains Pyro DMG +15%",
+        description: desc!("C6: During Pyronado, party gains Pyro DMG +15%"),
         stat: BuffableStat::ElementalDmgBonus(Element::Pyro),
         base_value: 0.15,
         scales_with_talent: false,
@@ -809,7 +825,7 @@ static XIANGLING_BUFFS: &[TalentBuffDef] = &[
     // C1: Guoba Pyro RES shred -15% (conditional toggle)
     TalentBuffDef {
         name: "xiangling_c1_pyro_res_shred",
-        description: "C1: Opponents hit by Guoba have Pyro RES -15%",
+        description: desc!("C1: Opponents hit by Guoba have Pyro RES -15%"),
         stat: BuffableStat::ElementalResReduction(Element::Pyro),
         base_value: 0.15,
         scales_with_talent: false,
@@ -824,7 +840,7 @@ static XIANGLING_BUFFS: &[TalentBuffDef] = &[
     // C6: Pyronado Pyro DMG +15% (conditional toggle)
     TalentBuffDef {
         name: "xiangling_c6_pyro_dmg",
-        description: "C6: During Pyronado, party gains Pyro DMG Bonus +15%",
+        description: desc!("C6: During Pyronado, party gains Pyro DMG Bonus +15%"),
         stat: BuffableStat::ElementalDmgBonus(Element::Pyro),
         base_value: 0.15,
         scales_with_talent: false,
@@ -845,7 +861,7 @@ static XIANGLING_BUFFS: &[TalentBuffDef] = &[
 static XINYAN_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Blazing Eye Physical RES Shred",
-        description: "C4: Enemies hit by Riff Revolution have Physical RES -15% for 12s",
+        description: desc!("C4: Enemies hit by Riff Revolution have Physical RES -15% for 12s"),
         stat: BuffableStat::PhysicalResReduction,
         base_value: 0.15,
         scales_with_talent: false,
@@ -860,7 +876,7 @@ static XINYAN_BUFFS: &[TalentBuffDef] = &[
     // C2: Burst Physical CRIT Rate +100% (approximation)
     TalentBuffDef {
         name: "xinyan_c2_burst_crit",
-        description: "C2: Riff Revolution Physical DMG CRIT Rate +100% (approximation)",
+        description: desc!("C2: Riff Revolution Physical DMG CRIT Rate +100% (approximation)"),
         stat: BuffableStat::CritRate,
         base_value: 1.00,
         scales_with_talent: false,
@@ -875,7 +891,7 @@ static XINYAN_BUFFS: &[TalentBuffDef] = &[
     // C6: Charged ATK flat DMG = 50% DEF
     TalentBuffDef {
         name: "xinyan_c6_charged_def_scaling",
-        description: "C6: Charged ATK gains ATK bonus equal to 50% of DEF",
+        description: desc!("C6: Charged ATK gains ATK bonus equal to 50% of DEF"),
         stat: BuffableStat::ChargedAtkFlatDmg,
         base_value: 0.50,
         scales_with_talent: false,
@@ -896,7 +912,9 @@ static XINYAN_BUFFS: &[TalentBuffDef] = &[
 static LYNEY_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Prestidigitation DMG Bonus",
-        description: "A4: DMG Bonus based on number of Pyro party members (max value 100% with all Pyro, Toggle)",
+        description: desc!(
+            "A4: DMG Bonus based on number of Pyro party members (max value 100% with all Pyro, Toggle)"
+        ),
         stat: BuffableStat::DmgBonus,
         base_value: 1.00,
         scales_with_talent: false,
@@ -910,7 +928,7 @@ static LYNEY_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Locquacious Cajoling CRIT DMG Bonus",
-        description: "C2: CRIT DMG +20% per stack, max 3 stacks",
+        description: desc!("C2: CRIT DMG +20% per stack, max 3 stacks"),
         stat: BuffableStat::CritDmg,
         base_value: 0.20,
         scales_with_talent: false,
@@ -924,7 +942,7 @@ static LYNEY_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Seated Next to Polished Nacre Pyro RES Shred",
-        description: "C4: Enemy Pyro RES -20%",
+        description: desc!("C4: Enemy Pyro RES -20%"),
         stat: BuffableStat::ElementalResReduction(Element::Pyro),
         base_value: 0.20,
         scales_with_talent: false,
@@ -944,7 +962,9 @@ static LYNEY_BUFFS: &[TalentBuffDef] = &[
 static YANFEI_BUFFS: &[TalentBuffDef] = &[
     TalentBuffDef {
         name: "Encyclopedic Expertise Pyro DMG Bonus",
-        description: "A1: Pyro DMG Bonus +5% per Scarlet Seal (max 4 seals = +20%, adopting max value)",
+        description: desc!(
+            "A1: Pyro DMG Bonus +5% per Scarlet Seal (max 4 seals = +20%, adopting max value)"
+        ),
         stat: BuffableStat::ElementalDmgBonus(Element::Pyro),
         base_value: 0.20,
         scales_with_talent: false,
@@ -958,7 +978,7 @@ static YANFEI_BUFFS: &[TalentBuffDef] = &[
     },
     TalentBuffDef {
         name: "Blazing Eye Charged ATK CRIT Rate Bonus",
-        description: "C2: Charged ATK CRIT Rate +20%",
+        description: desc!("C2: Charged ATK CRIT Rate +20%"),
         stat: BuffableStat::ChargedAtkDmgBonus,
         base_value: 0.20,
         scales_with_talent: false,

--- a/crates/data/src/weapons/bow.rs
+++ b/crates/data/src/weapons/bow.rs
@@ -19,7 +19,7 @@ pub const AMOS_BOW: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "矢についた強風",
         effect: PassiveEffect {
-            description: "NA/CA DMG+12-24%。矢が0.1秒飛ぶごとにさらにDMG+8%、最大5スタック",
+            description: desc!("NA/CA DMG+12-24%。矢が0.1秒飛ぶごとにさらにDMG+8%、最大5スタック"),
             buffs: &[
                 StatBuff {
                     stat: BuffableStat::NormalAtkDmgBonus,
@@ -35,7 +35,7 @@ pub const AMOS_BOW: WeaponData = WeaponData {
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "amos_bow_flight_na",
-                    description: "矢の飛行時間0.1秒毎にNA DMG+8-16%、最大5スタック",
+                    description: desc!("矢の飛行時間0.1秒毎にNA DMG+8-16%、最大5スタック"),
                     stat: BuffableStat::NormalAtkDmgBonus,
                     value: 0.08,
                     nightsoul_value: None,
@@ -46,7 +46,7 @@ pub const AMOS_BOW: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "amos_bow_flight_ca",
-                    description: "矢の飛行時間0.1秒毎にCA DMG+8-16%、最大5スタック",
+                    description: desc!("矢の飛行時間0.1秒毎にCA DMG+8-16%、最大5スタック"),
                     stat: BuffableStat::ChargedAtkDmgBonus,
                     value: 0.08,
                     nightsoul_value: None,
@@ -70,7 +70,7 @@ pub const AQUA_SIMULACRA: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "幽水のワルツ",
         effect: PassiveEffect {
-            description: "HP+16-32%。付近に敵がいる時DMG+20-40%",
+            description: desc!("HP+16-32%。付近に敵がいる時DMG+20-40%"),
             buffs: &[StatBuff {
                 stat: BuffableStat::HpPercent,
                 value: 0.16,
@@ -78,7 +78,7 @@ pub const AQUA_SIMULACRA: WeaponData = WeaponData {
             }],
             conditional_buffs: &[ConditionalBuff {
                 name: "aqua_simulacra_dmg",
-                description: "付近に敵が存在する時、DMG+20-40%",
+                description: desc!("付近に敵が存在する時、DMG+20-40%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.20,
                 nightsoul_value: None,
@@ -101,12 +101,14 @@ pub const ASTRAL_VULTURES_CRIMSON_PLUMAGE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Astral Vulture's Crimson Plumage",
         effect: PassiveEffect {
-            description: "夜魂スタック蓄積でATK+12-24%（最大3スタック）、フルスタックでDMG+12-24%",
+            description: desc!(
+                "夜魂スタック蓄積でATK+12-24%（最大3スタック）、フルスタックでDMG+12-24%"
+            ),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "astral_vulture_atk_stacks",
-                    description: "夜魂スタックでATK+12-24%（1スタック）、最大3スタック",
+                    description: desc!("夜魂スタックでATK+12-24%（1スタック）、最大3スタック"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.12,
                     nightsoul_value: None,
@@ -117,7 +119,7 @@ pub const ASTRAL_VULTURES_CRIMSON_PLUMAGE: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "astral_vulture_full_stack_dmg",
-                    description: "フルスタック時にDMG+12-24%",
+                    description: desc!("フルスタック時にDMG+12-24%"),
                     stat: BuffableStat::DmgBonus,
                     value: 0.12,
                     nightsoul_value: None,
@@ -141,7 +143,7 @@ pub const ELEGY_FOR_THE_END: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "別離の哀歌",
         effect: PassiveEffect {
-            description: "EM+60-120。追憶の印蓄積でチーム全員にEM+100-200/ATK+20-40%",
+            description: desc!("EM+60-120。追憶の印蓄積でチーム全員にEM+100-200/ATK+20-40%"),
             buffs: &[StatBuff {
                 stat: BuffableStat::ElementalMastery,
                 value: 60.0,
@@ -150,7 +152,7 @@ pub const ELEGY_FOR_THE_END: WeaponData = WeaponData {
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "elegy_team_em",
-                    description: "追憶の印フルスタック時にチーム全員EM+100-200",
+                    description: desc!("追憶の印フルスタック時にチーム全員EM+100-200"),
                     stat: BuffableStat::ElementalMastery,
                     value: 100.0,
                     nightsoul_value: None,
@@ -161,7 +163,7 @@ pub const ELEGY_FOR_THE_END: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "elegy_team_atk",
-                    description: "追憶の印フルスタック時にチーム全員ATK+20-40%",
+                    description: desc!("追憶の印フルスタック時にチーム全員ATK+20-40%"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.20,
                     nightsoul_value: None,
@@ -185,7 +187,7 @@ pub const HUNTERS_PATH: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "狩路の巡星",
         effect: PassiveEffect {
-            description: "Ele DMG+12-24%。CAがEMに基づき追加ダメージ",
+            description: desc!("Ele DMG+12-24%。CAがEMに基づき追加ダメージ"),
             buffs: &[StatBuff {
                 stat: BuffableStat::DmgBonus,
                 value: 0.12,
@@ -193,7 +195,7 @@ pub const HUNTERS_PATH: WeaponData = WeaponData {
             }],
             conditional_buffs: &[ConditionalBuff {
                 name: "hunters_path_em_ca_flat",
-                description: "EM×160-320%分を重撃フラットダメージに加算",
+                description: desc!("EM×160-320%分を重撃フラットダメージに加算"),
                 stat: BuffableStat::ChargedAtkFlatDmg,
                 value: 1.60,
                 nightsoul_value: None,
@@ -223,7 +225,7 @@ pub const POLAR_STAR: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "極夜の白星",
         effect: PassiveEffect {
-            description: "Skill/Burst DMG+12-24%。白極のスタック蓄積でATKアップ",
+            description: desc!("Skill/Burst DMG+12-24%。白極のスタック蓄積でATKアップ"),
             buffs: &[
                 StatBuff {
                     stat: BuffableStat::SkillDmgBonus,
@@ -238,7 +240,7 @@ pub const POLAR_STAR: WeaponData = WeaponData {
             ],
             conditional_buffs: &[ConditionalBuff {
                 name: "polar_star_atk_stacks",
-                description: "白極の紋スタックでATKアップ（非線形: 10%/20%/30%/48%）",
+                description: desc!("白極の紋スタックでATKアップ（非線形: 10%/20%/30%/48%）"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.10,
                 nightsoul_value: None,
@@ -261,12 +263,14 @@ pub const SILVERSHOWER_HEARTSTRINGS: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Silvershower Heartstrings",
         effect: PassiveEffect {
-            description: "元素スキル使用でHP+12-24%スタック（最大3）、3スタックでHydro DMG+28-56%",
+            description: desc!(
+                "元素スキル使用でHP+12-24%スタック（最大3）、3スタックでHydro DMG+28-56%"
+            ),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "silvershower_hp_stacks",
-                    description: "元素スキル使用でHP+12-24%（1スタック）、最大3スタック",
+                    description: desc!("元素スキル使用でHP+12-24%（1スタック）、最大3スタック"),
                     stat: BuffableStat::HpPercent,
                     value: 0.12,
                     nightsoul_value: None,
@@ -277,7 +281,7 @@ pub const SILVERSHOWER_HEARTSTRINGS: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "silvershower_full_stack_hydro_dmg",
-                    description: "3スタック時にHydro DMG+28-56%",
+                    description: desc!("3スタック時にHydro DMG+28-56%"),
                     stat: BuffableStat::ElementalDmgBonus(Element::Hydro),
                     value: 0.28,
                     nightsoul_value: None,
@@ -301,7 +305,7 @@ pub const SKYWARD_HARP: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "天空のアルペジオ",
         effect: PassiveEffect {
-            description: "CRIT DMG+20-40%。命中時に追加範囲DMG発生",
+            description: desc!("CRIT DMG+20-40%。命中時に追加範囲DMG発生"),
             buffs: &[StatBuff {
                 stat: BuffableStat::CritDmg,
                 value: 0.20,
@@ -322,11 +326,11 @@ pub const THE_DAYBREAK_CHRONICLES: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "The Daybreak Chronicles",
         effect: PassiveEffect {
-            description: "物語のスタック蓄積でDMG+8-16%（最大3スタック）",
+            description: desc!("物語のスタック蓄積でDMG+8-16%（最大3スタック）"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "the_daybreak_chronicles_dmg_stacks",
-                description: "物語のスタックでDMG+8-16%（1スタック）、最大3スタック",
+                description: desc!("物語のスタックでDMG+8-16%（1スタック）、最大3スタック"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.08,
                 nightsoul_value: None,
@@ -349,7 +353,7 @@ pub const THE_FIRST_GREAT_MAGIC: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "至高の魔術",
         effect: PassiveEffect {
-            description: "CA DMG+16-32%。チームメンバーの元素タイプに応じATKアップ",
+            description: desc!("CA DMG+16-32%。チームメンバーの元素タイプに応じATKアップ"),
             buffs: &[StatBuff {
                 stat: BuffableStat::ChargedAtkDmgBonus,
                 value: 0.16,
@@ -358,7 +362,7 @@ pub const THE_FIRST_GREAT_MAGIC: WeaponData = WeaponData {
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "first_great_magic_atk_1",
-                    description: "1+異元素チームメンバーでATK+16-32%",
+                    description: desc!("1+異元素チームメンバーでATK+16-32%"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.16,
                     nightsoul_value: None,
@@ -371,7 +375,7 @@ pub const THE_FIRST_GREAT_MAGIC: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "first_great_magic_atk_2",
-                    description: "2+異元素チームメンバーでATK+16-32%",
+                    description: desc!("2+異元素チームメンバーでATK+16-32%"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.16,
                     nightsoul_value: None,
@@ -384,7 +388,7 @@ pub const THE_FIRST_GREAT_MAGIC: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "first_great_magic_atk_3",
-                    description: "3+異元素チームメンバーでATK+16-32%",
+                    description: desc!("3+異元素チームメンバーでATK+16-32%"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.16,
                     nightsoul_value: None,
@@ -410,7 +414,7 @@ pub const THUNDERING_PULSE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "飛雷の鳴弦",
         effect: PassiveEffect {
-            description: "ATK+20-40%。雷の巴紋を蓄積してNA DMGアップ",
+            description: desc!("ATK+20-40%。雷の巴紋を蓄積してNA DMGアップ"),
             buffs: &[StatBuff {
                 stat: BuffableStat::AtkPercent,
                 value: 0.20,
@@ -418,7 +422,7 @@ pub const THUNDERING_PULSE: WeaponData = WeaponData {
             }],
             conditional_buffs: &[ConditionalBuff {
                 name: "thundering_pulse_na_stacks",
-                description: "雷の巴紋スタックでNA DMGアップ（非線形: 12%/24%/40%）",
+                description: desc!("雷の巴紋スタックでNA DMGアップ（非線形: 12%/24%/40%）"),
                 stat: BuffableStat::NormalAtkDmgBonus,
                 value: 0.12,
                 nightsoul_value: None,
@@ -445,11 +449,11 @@ pub const ALLEY_HUNTER: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "裏通りの伏兵",
         effect: PassiveEffect {
-            description: "Conditional: 待機時にDMGアップ、戦闘中にDMGダウン",
+            description: desc!("Conditional: 待機時にDMGアップ、戦闘中にDMGダウン"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "alley_hunter_dmg",
-                description: "待機中1秒毎にDMG+2-4%、最大10スタック（4秒出場で解除）",
+                description: desc!("待機中1秒毎にDMG+2-4%、最大10スタック（4秒出場で解除）"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.02,
                 nightsoul_value: None,
@@ -472,11 +476,11 @@ pub const BLACKCLIFF_WARBOW: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "追撃の矢",
         effect: PassiveEffect {
-            description: "Conditional: 敵撃破時にATKアップ、最大3スタック",
+            description: desc!("Conditional: 敵撃破時にATKアップ、最大3スタック"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "blackcliff_warbow_atk",
-                description: "敵撃破後にATK+12-24%、最大3スタック",
+                description: desc!("敵撃破後にATK+12-24%、最大3スタック"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.12,
                 nightsoul_value: None,
@@ -499,12 +503,14 @@ pub const CHAIN_BREAKER: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Chain Breaker",
         effect: PassiveEffect {
-            description: "Conditional: チームの元素タイプに応じてEM/ATKアップ",
+            description: desc!("Conditional: チームの元素タイプに応じてEM/ATKアップ"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "chain_breaker_em",
-                    description: "チーム元素種類数に応じてEM+36-60-84-100（スタック数=元素種類数）",
+                    description: desc!(
+                        "チーム元素種類数に応じてEM+36-60-84-100（スタック数=元素種類数）"
+                    ),
                     stat: BuffableStat::ElementalMastery,
                     value: 36.0,
                     nightsoul_value: None,
@@ -515,7 +521,9 @@ pub const CHAIN_BREAKER: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "chain_breaker_atk",
-                    description: "チーム元素種類数に応じてATK+8-9-10-11%（スタック数=元素種類数）",
+                    description: desc!(
+                        "チーム元素種類数に応じてATK+8-9-10-11%（スタック数=元素種類数）"
+                    ),
                     stat: BuffableStat::AtkPercent,
                     value: 0.08,
                     nightsoul_value: None,
@@ -539,11 +547,11 @@ pub const CLOUDFORGED: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Cloudforged",
         effect: PassiveEffect {
-            description: "Conditional: 元素エネルギー消費後にチーム全員のEMアップ",
+            description: desc!("Conditional: 元素エネルギー消費後にチーム全員のEMアップ"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "cloudforged_team_em",
-                description: "元素エネルギー消費後にチーム全員EM+40-80",
+                description: desc!("元素エネルギー消費後にチーム全員EM+40-80"),
                 stat: BuffableStat::ElementalMastery,
                 value: 40.0,
                 nightsoul_value: None,
@@ -568,11 +576,11 @@ pub const COMPOUND_BOW: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "重錬の矢",
         effect: PassiveEffect {
-            description: "Conditional: NA/CA命中時にATK+4%/NA速度+1.2%、最大4スタック",
+            description: desc!("Conditional: NA/CA命中時にATK+4%/NA速度+1.2%、最大4スタック"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "compound_bow_atk",
-                description: "NA/CA命中時にATK+4-8%、最大4スタック（攻撃速度バフは非対応）",
+                description: desc!("NA/CA命中時にATK+4-8%、最大4スタック（攻撃速度バフは非対応）"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.04,
                 nightsoul_value: None,
@@ -595,7 +603,9 @@ pub const END_OF_THE_LINE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "川漁の極み",
         effect: PassiveEffect {
-            description: "Conditional: 元素エネルギー獲得でフグ蓄積、Skill/Burst命中時に爆発ダメージ",
+            description: desc!(
+                "Conditional: 元素エネルギー獲得でフグ蓄積、Skill/Burst命中時に爆発ダメージ"
+            ),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -612,11 +622,11 @@ pub const FADING_TWILIGHT: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "暮色の薄明",
         effect: PassiveEffect {
-            description: "夕暮(6%)/流明(10%)/朝暉(14%)の3状態を循環してDMGアップ",
+            description: desc!("夕暮(6%)/流明(10%)/朝暉(14%)の3状態を循環してDMGアップ"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "fading_twilight_dmg",
-                description: "夕暮(6%)/流明(10%)/朝暉(14%)の3状態を循環してDMGアップ",
+                description: desc!("夕暮(6%)/流明(10%)/朝暉(14%)の3状態を循環してDMGアップ"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.06,
                 nightsoul_value: None,
@@ -639,7 +649,7 @@ pub const FAVONIUS_WARBOW: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "西風の矢",
         effect: PassiveEffect {
-            description: "Conditional: 会心時に元素粒子を生成、12秒に1回",
+            description: desc!("Conditional: 会心時に元素粒子を生成、12秒に1回"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -656,11 +666,11 @@ pub const FLOWER_WREATHED_FEATHERS: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Flower-Wreathed Feathers",
         effect: PassiveEffect {
-            description: "Conditional: 元素反応後にDMGアップ",
+            description: desc!("Conditional: 元素反応後にDMGアップ"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "flower_wreathed_dmg",
-                description: "元素反応発動後にDMG+16-32%",
+                description: desc!("元素反応発動後にDMG+16-32%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.16,
                 nightsoul_value: None,
@@ -683,7 +693,9 @@ pub const HAMAYUMI: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "待ち伏せの矢",
         effect: PassiveEffect {
-            description: "NA DMG+16-32%/CA DMG+12-24%。エネルギー満タンでさらにNA DMG+16-32%/CA DMG+12-24%",
+            description: desc!(
+                "NA DMG+16-32%/CA DMG+12-24%。エネルギー満タンでさらにNA DMG+16-32%/CA DMG+12-24%"
+            ),
             buffs: &[
                 StatBuff {
                     stat: BuffableStat::NormalAtkDmgBonus,
@@ -699,7 +711,7 @@ pub const HAMAYUMI: WeaponData = WeaponData {
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "hamayumi_full_energy_na",
-                    description: "エネルギー満タン時にNA DMG+16-32%",
+                    description: desc!("エネルギー満タン時にNA DMG+16-32%"),
                     stat: BuffableStat::NormalAtkDmgBonus,
                     value: 0.16,
                     nightsoul_value: None,
@@ -710,7 +722,7 @@ pub const HAMAYUMI: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "hamayumi_full_energy_ca",
-                    description: "エネルギー満タン時にCA DMG+12-24%",
+                    description: desc!("エネルギー満タン時にCA DMG+12-24%"),
                     stat: BuffableStat::ChargedAtkDmgBonus,
                     value: 0.12,
                     nightsoul_value: None,
@@ -734,11 +746,11 @@ pub const IBIS_PIERCER: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Ibis Piercer",
         effect: PassiveEffect {
-            description: "Conditional: CA命中時にEMアップ、最大2スタック",
+            description: desc!("Conditional: CA命中時にEMアップ、最大2スタック"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "ibis_piercer_em",
-                description: "CA命中時にEM+20-40、最大2スタック",
+                description: desc!("CA命中時にEM+20-40、最大2スタック"),
                 stat: BuffableStat::ElementalMastery,
                 value: 20.0,
                 nightsoul_value: None,
@@ -761,11 +773,13 @@ pub const KINGS_SQUIRE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "森の従者",
         effect: PassiveEffect {
-            description: "Conditional: スキル/バースト使用時にEMアップ。矢を放って追加ダメージ",
+            description: desc!(
+                "Conditional: スキル/バースト使用時にEMアップ。矢を放って追加ダメージ"
+            ),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "kings_squire_em",
-                description: "スキル/バースト使用後にEM+60-120",
+                description: desc!("スキル/バースト使用後にEM+60-120"),
                 stat: BuffableStat::ElementalMastery,
                 value: 60.0,
                 nightsoul_value: None,
@@ -790,12 +804,12 @@ pub const MITTERNACHTS_WALTZ: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "影の弾幕",
         effect: PassiveEffect {
-            description: "通常攻撃命中時にSkill DMG+20-40%、元素スキル命中時にNA DMG+20-40%",
+            description: desc!("通常攻撃命中時にSkill DMG+20-40%、元素スキル命中時にNA DMG+20-40%"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "mitternachts_skill_dmg",
-                    description: "通常攻撃命中時にSkill DMG+20-40%",
+                    description: desc!("通常攻撃命中時にSkill DMG+20-40%"),
                     stat: BuffableStat::SkillDmgBonus,
                     value: 0.20,
                     nightsoul_value: None,
@@ -806,7 +820,7 @@ pub const MITTERNACHTS_WALTZ: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "mitternachts_na_dmg",
-                    description: "元素スキル命中時にNA DMG+20-40%",
+                    description: desc!("元素スキル命中時にNA DMG+20-40%"),
                     stat: BuffableStat::NormalAtkDmgBonus,
                     value: 0.20,
                     nightsoul_value: None,
@@ -830,11 +844,15 @@ pub const MOUUNS_MOON: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "海淵の月",
         effect: PassiveEffect {
-            description: "チーム全員の元素エネルギー上限合計に基づきBurst DMG+最大40-80%（総EP240超時）",
+            description: desc!(
+                "チーム全員の元素エネルギー上限合計に基づきBurst DMG+最大40-80%（総EP240超時）"
+            ),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "mouuns_moon_burst_dmg",
-                description: "チーム全員の元素エネルギー上限合計に基づきBurst DMG+最大40-80%（240EP基準）",
+                description: desc!(
+                    "チーム全員の元素エネルギー上限合計に基づきBurst DMG+最大40-80%（240EP基準）"
+                ),
                 stat: BuffableStat::BurstDmgBonus,
                 value: 0.40,
                 nightsoul_value: None,
@@ -857,12 +875,14 @@ pub const PREDATOR: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Predator",
         effect: PassiveEffect {
-            description: "Cryo命中後にNA DMG+10%/CA DMG+10%（精錬固定）。アーロイ装備時にATK+66",
+            description: desc!(
+                "Cryo命中後にNA DMG+10%/CA DMG+10%（精錬固定）。アーロイ装備時にATK+66"
+            ),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "predator_na_dmg",
-                    description: "Cryo命中後にNA DMG+10%（精錬固定）",
+                    description: desc!("Cryo命中後にNA DMG+10%（精錬固定）"),
                     stat: BuffableStat::NormalAtkDmgBonus,
                     value: 0.10,
                     nightsoul_value: None,
@@ -873,7 +893,7 @@ pub const PREDATOR: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "predator_ca_dmg",
-                    description: "Cryo命中後にCA DMG+10%（精錬固定）",
+                    description: desc!("Cryo命中後にCA DMG+10%（精錬固定）"),
                     stat: BuffableStat::ChargedAtkDmgBonus,
                     value: 0.10,
                     nightsoul_value: None,
@@ -897,11 +917,11 @@ pub const PROTOTYPE_CRESCENT: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "月影の矢",
         effect: PassiveEffect {
-            description: "弱点命中時にATK+36-72%、10秒",
+            description: desc!("弱点命中時にATK+36-72%、10秒"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "prototype_crescent_atk",
-                description: "弱点命中時にATK+36-72%",
+                description: desc!("弱点命中時にATK+36-72%"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.36,
                 nightsoul_value: None,
@@ -924,11 +944,11 @@ pub const RAINBOW_SERPENTS_RAIN_BOW: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Rainbow Serpent's Rain Bow",
         effect: PassiveEffect {
-            description: "Conditional: チームメンバーの元素タイプに応じてDMGアップ",
+            description: desc!("Conditional: チームメンバーの元素タイプに応じてDMGアップ"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "rainbow_serpent_dmg",
-                description: "チームの元素種類数分DMG+5-10%（スタック数=チーム元素種類数）",
+                description: desc!("チームの元素種類数分DMG+5-10%（スタック数=チーム元素種類数）"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.05,
                 nightsoul_value: None,
@@ -951,11 +971,11 @@ pub const RANGE_GAUGE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Range Gauge",
         effect: PassiveEffect {
-            description: "Conditional: CA命中時にスタック蓄積でATKアップ",
+            description: desc!("Conditional: CA命中時にスタック蓄積でATKアップ"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "range_gauge_atk",
-                description: "CA命中時にATK+4-8%スタック蓄積、最大4スタック",
+                description: desc!("CA命中時にATK+4-8%スタック蓄積、最大4スタック"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.04,
                 nightsoul_value: None,
@@ -978,11 +998,15 @@ pub const ROYAL_BOW: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "集中",
         effect: PassiveEffect {
-            description: "Conditional: ダメージ時にCRIT Rate+8%、最大5スタック。会心でリセット",
+            description: desc!(
+                "Conditional: ダメージ時にCRIT Rate+8%、最大5スタック。会心でリセット"
+            ),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "royal_bow_cr",
-                description: "ダメージ時にCRIT Rate+8-16%、最大5スタック（会心命中でリセット）",
+                description: desc!(
+                    "ダメージ時にCRIT Rate+8-16%、最大5スタック（会心命中でリセット）"
+                ),
                 stat: BuffableStat::CritRate,
                 value: 0.08,
                 nightsoul_value: None,
@@ -1005,7 +1029,7 @@ pub const RUST: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "速射の弦",
         effect: PassiveEffect {
-            description: "NA DMG+40-80%。CA DMG-10%",
+            description: desc!("NA DMG+40-80%。CA DMG-10%"),
             buffs: &[StatBuff {
                 stat: BuffableStat::NormalAtkDmgBonus,
                 value: 0.40,
@@ -1026,7 +1050,7 @@ pub const SACRIFICIAL_BOW: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "気定神閑",
         effect: PassiveEffect {
-            description: "Conditional: 元素スキルがダメージを与えた時にCD終了、30秒に1回",
+            description: desc!("Conditional: 元素スキルがダメージを与えた時にCD終了、30秒に1回"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -1043,11 +1067,13 @@ pub const SCION_OF_THE_BLAZING_SUN: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "灼熱の太陽の子",
         effect: PassiveEffect {
-            description: "Conditional: CA命中でCA DMGアップ。チームがDendro反応を起こすとさらにアップ",
+            description: desc!(
+                "Conditional: CA命中でCA DMGアップ。チームがDendro反応を起こすとさらにアップ"
+            ),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "scion_blazing_sun_ca",
-                description: "CA命中後にCA DMG+28-56%",
+                description: desc!("CA命中後にCA DMG+28-56%"),
                 stat: BuffableStat::ChargedAtkDmgBonus,
                 value: 0.28,
                 nightsoul_value: None,
@@ -1070,12 +1096,12 @@ pub const SEQUENCE_OF_SOLITUDE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Sequence of Solitude",
         effect: PassiveEffect {
-            description: "HP変動時にSkill DMG+14-28%/Burst DMG+14-28%、6秒",
+            description: desc!("HP変動時にSkill DMG+14-28%/Burst DMG+14-28%、6秒"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "sequence_skill_dmg",
-                    description: "HP変動時にSkill DMG+14-28%",
+                    description: desc!("HP変動時にSkill DMG+14-28%"),
                     stat: BuffableStat::SkillDmgBonus,
                     value: 0.14,
                     nightsoul_value: None,
@@ -1086,7 +1112,7 @@ pub const SEQUENCE_OF_SOLITUDE: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "sequence_burst_dmg",
-                    description: "HP変動時にBurst DMG+14-28%",
+                    description: desc!("HP変動時にBurst DMG+14-28%"),
                     stat: BuffableStat::BurstDmgBonus,
                     value: 0.14,
                     nightsoul_value: None,
@@ -1110,11 +1136,11 @@ pub const SNARE_HOOK: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Snare Hook",
         effect: PassiveEffect {
-            description: "元素スキル命中後にDMG+16-32%、10秒",
+            description: desc!("元素スキル命中後にDMG+16-32%、10秒"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "snare_hook_dmg",
-                description: "元素スキル命中後にDMG+16-32%",
+                description: desc!("元素スキル命中後にDMG+16-32%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.16,
                 nightsoul_value: None,
@@ -1137,11 +1163,11 @@ pub const SONG_OF_STILLNESS: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Song of Stillness",
         effect: PassiveEffect {
-            description: "Conditional: HP回復後にDMGアップ、8秒",
+            description: desc!("Conditional: HP回復後にDMGアップ、8秒"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "song_of_stillness_dmg",
-                description: "HP回復後にDMG+16-32%",
+                description: desc!("HP回復後にDMG+16-32%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.16,
                 nightsoul_value: None,
@@ -1164,7 +1190,7 @@ pub const THE_STRINGLESS: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "琴弓の詩",
         effect: PassiveEffect {
-            description: "Skill/Burst DMG+24-48%",
+            description: desc!("Skill/Burst DMG+24-48%"),
             buffs: &[
                 StatBuff {
                     stat: BuffableStat::SkillDmgBonus,
@@ -1192,7 +1218,7 @@ pub const THE_VIRIDESCENT_HUNT: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "緑の狩猟",
         effect: PassiveEffect {
-            description: "Conditional: NA/CA命中時に風の渦を発生、14秒に1回",
+            description: desc!("Conditional: NA/CA命中時に風の渦を発生、14秒に1回"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -1209,11 +1235,11 @@ pub const WINDBLUME_ODE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "風花の願い",
         effect: PassiveEffect {
-            description: "元素スキル使用後にATK+16-32%、6秒",
+            description: desc!("元素スキル使用後にATK+16-32%、6秒"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "windblume_atk",
-                description: "元素スキル使用後にATK+16-32%",
+                description: desc!("元素スキル使用後にATK+16-32%"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.16,
                 nightsoul_value: None,
@@ -1240,7 +1266,7 @@ pub const MESSENGER: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "射手の教え",
         effect: PassiveEffect {
-            description: "Conditional: CA弱点命中時に追加ATKダメージ100%、10秒に1回",
+            description: desc!("Conditional: CA弱点命中時に追加ATKダメージ100%、10秒に1回"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -1257,11 +1283,11 @@ pub const RAVEN_BOW: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "烏の羽",
         effect: PassiveEffect {
-            description: "水/炎元素影響下の敵へのDMG+12-24%",
+            description: desc!("水/炎元素影響下の敵へのDMG+12-24%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "raven_bow_dmg",
-                description: "水/炎元素影響下の敵へのDMG+12-24%",
+                description: desc!("水/炎元素影響下の敵へのDMG+12-24%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.12,
                 nightsoul_value: None,
@@ -1284,7 +1310,7 @@ pub const RECURVE_BOW: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "気力回復",
         effect: PassiveEffect {
-            description: "Conditional: 敵撃破時にHP回復8%",
+            description: desc!("Conditional: 敵撃破時にHP回復8%"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -1301,11 +1327,11 @@ pub const SHARPSHOOTERS_OATH: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "精密射撃",
         effect: PassiveEffect {
-            description: "弱点命中時にDMG+24-48%",
+            description: desc!("弱点命中時にDMG+24-48%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "sharpshooters_oath_dmg",
-                description: "弱点命中時にDMG+24-48%",
+                description: desc!("弱点命中時にDMG+24-48%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.24,
                 nightsoul_value: None,
@@ -1328,11 +1354,11 @@ pub const SLINGSHOT: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "弾き出す",
         effect: PassiveEffect {
-            description: "矢が0.3秒以内に命中でNA/CA DMG+36-60%（遠距離は-10%）",
+            description: desc!("矢が0.3秒以内に命中でNA/CA DMG+36-60%（遠距離は-10%）"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "slingshot_dmg",
-                description: "矢が0.3秒以内（近距離）に命中でNA/CA DMG+36-60%",
+                description: desc!("矢が0.3秒以内（近距離）に命中でNA/CA DMG+36-60%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.36,
                 nightsoul_value: None,

--- a/crates/data/src/weapons/catalyst.rs
+++ b/crates/data/src/weapons/catalyst.rs
@@ -18,12 +18,12 @@ pub const A_THOUSAND_FLOATING_DREAMS: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "A Thousand Floating Dreams",
         effect: PassiveEffect {
-            description: "同元素1人毎にEM+32-64、異元素1人毎にDMG+10-26%。チームにEM+40-56",
+            description: desc!("同元素1人毎にEM+32-64、異元素1人毎にDMG+10-26%。チームにEM+40-56"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "thousand_dreams_same1_em",
-                    description: "1+同元素チームメンバーでEM+32-64",
+                    description: desc!("1+同元素チームメンバーでEM+32-64"),
                     stat: BuffableStat::ElementalMastery,
                     value: 32.0,
                     nightsoul_value: None,
@@ -36,7 +36,7 @@ pub const A_THOUSAND_FLOATING_DREAMS: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "thousand_dreams_same2_em",
-                    description: "2+同元素チームメンバーでEM+32-64",
+                    description: desc!("2+同元素チームメンバーでEM+32-64"),
                     stat: BuffableStat::ElementalMastery,
                     value: 32.0,
                     nightsoul_value: None,
@@ -49,7 +49,7 @@ pub const A_THOUSAND_FLOATING_DREAMS: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "thousand_dreams_same3_em",
-                    description: "3+同元素チームメンバーでEM+32-64",
+                    description: desc!("3+同元素チームメンバーでEM+32-64"),
                     stat: BuffableStat::ElementalMastery,
                     value: 32.0,
                     nightsoul_value: None,
@@ -62,7 +62,7 @@ pub const A_THOUSAND_FLOATING_DREAMS: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "thousand_dreams_diff1_dmg",
-                    description: "1+異元素チームメンバーでDMG+10-26%",
+                    description: desc!("1+異元素チームメンバーでDMG+10-26%"),
                     stat: BuffableStat::DmgBonus,
                     value: 0.10,
                     nightsoul_value: None,
@@ -75,7 +75,7 @@ pub const A_THOUSAND_FLOATING_DREAMS: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "thousand_dreams_diff2_dmg",
-                    description: "2+異元素チームメンバーでDMG+10-26%",
+                    description: desc!("2+異元素チームメンバーでDMG+10-26%"),
                     stat: BuffableStat::DmgBonus,
                     value: 0.10,
                     nightsoul_value: None,
@@ -88,7 +88,7 @@ pub const A_THOUSAND_FLOATING_DREAMS: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "thousand_dreams_diff3_dmg",
-                    description: "3+異元素チームメンバーでDMG+10-26%",
+                    description: desc!("3+異元素チームメンバーでDMG+10-26%"),
                     stat: BuffableStat::DmgBonus,
                     value: 0.10,
                     nightsoul_value: None,
@@ -101,7 +101,7 @@ pub const A_THOUSAND_FLOATING_DREAMS: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "thousand_dreams_team_em",
-                    description: "チームメンバーにEM+40-56",
+                    description: desc!("チームメンバーにEM+40-56"),
                     stat: BuffableStat::ElementalMastery,
                     value: 40.0,
                     nightsoul_value: None,
@@ -125,7 +125,7 @@ pub const CASHFLOW_SUPERVISION: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Cashflow Supervision",
         effect: PassiveEffect {
-            description: "ATK+16-32%、NA/CA DMG+16-32%。HP変動後CA DMG追加+16-32%",
+            description: desc!("ATK+16-32%、NA/CA DMG+16-32%。HP変動後CA DMG追加+16-32%"),
             buffs: &[
                 StatBuff {
                     stat: BuffableStat::AtkPercent,
@@ -145,7 +145,7 @@ pub const CASHFLOW_SUPERVISION: WeaponData = WeaponData {
             ],
             conditional_buffs: &[ConditionalBuff {
                 name: "cashflow_supervision_ca_dmg",
-                description: "HP変動（回復/被ダメ）後にCA DMG追加+16-32%",
+                description: desc!("HP変動（回復/被ダメ）後にCA DMG追加+16-32%"),
                 stat: BuffableStat::ChargedAtkDmgBonus,
                 value: 0.16,
                 nightsoul_value: None,
@@ -168,7 +168,7 @@ pub const CRANES_ECHOING_CALL: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Crane's Echoing Call",
         effect: PassiveEffect {
-            description: "Plunging DMG+28-56%。落下攻撃命中後チーム全員の落下攻撃DMG+28-56%",
+            description: desc!("Plunging DMG+28-56%。落下攻撃命中後チーム全員の落下攻撃DMG+28-56%"),
             buffs: &[StatBuff {
                 stat: BuffableStat::PlungingAtkDmgBonus,
                 value: 0.28,
@@ -176,7 +176,7 @@ pub const CRANES_ECHOING_CALL: WeaponData = WeaponData {
             }],
             conditional_buffs: &[ConditionalBuff {
                 name: "cranes_echoing_call_team_plunge",
-                description: "落下攻撃命中後にチーム全員の落下攻撃DMG+28-56%",
+                description: desc!("落下攻撃命中後にチーム全員の落下攻撃DMG+28-56%"),
                 stat: BuffableStat::PlungingAtkDmgBonus,
                 value: 0.28,
                 nightsoul_value: None,
@@ -199,7 +199,9 @@ pub const EVERLASTING_MOONGLOW: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Everlasting Moonglow",
         effect: PassiveEffect {
-            description: "Heal+10-20%。NA DMG+HP上限の1-2%。元素爆発後12秒間NA DMG+HP上限の0.7-1.4%",
+            description: desc!(
+                "Heal+10-20%。NA DMG+HP上限の1-2%。元素爆発後12秒間NA DMG+HP上限の0.7-1.4%"
+            ),
             buffs: &[StatBuff {
                 stat: BuffableStat::HealingBonus,
                 value: 0.10,
@@ -208,7 +210,7 @@ pub const EVERLASTING_MOONGLOW: WeaponData = WeaponData {
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "everlasting_moonglow_na_hp",
-                    description: "HP上限の1-2%分、通常攻撃に追加ダメージ（常時）",
+                    description: desc!("HP上限の1-2%分、通常攻撃に追加ダメージ（常時）"),
                     stat: BuffableStat::NormalAtkFlatDmg,
                     value: 0.010,
                     nightsoul_value: None,
@@ -223,7 +225,9 @@ pub const EVERLASTING_MOONGLOW: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "everlasting_moonglow_burst_na_hp",
-                    description: "元素爆発後12秒間、HP上限の0.7-1.4%分の通常攻撃追加ダメージ",
+                    description: desc!(
+                        "元素爆発後12秒間、HP上限の0.7-1.4%分の通常攻撃追加ダメージ"
+                    ),
                     stat: BuffableStat::NormalAtkFlatDmg,
                     value: 0.007,
                     nightsoul_value: None,
@@ -254,11 +258,11 @@ pub const JADEFALLS_SPLENDOR: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Jadefall's Splendor",
         effect: PassiveEffect {
-            description: "元素エネルギー消費後にEM+32-64",
+            description: desc!("元素エネルギー消費後にEM+32-64"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "jadefall_em",
-                description: "元素エネルギー消費後にEM+32-64",
+                description: desc!("元素エネルギー消費後にEM+32-64"),
                 stat: BuffableStat::ElementalMastery,
                 value: 32.0,
                 nightsoul_value: None,
@@ -281,12 +285,16 @@ pub const KAGURAS_VERITY: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Kagura's Verity",
         effect: PassiveEffect {
-            description: "元素スキル使用でスキルDMG+12-24%スタック（最大3）、3スタックで元素DMG+12-24%",
+            description: desc!(
+                "元素スキル使用でスキルDMG+12-24%スタック（最大3）、3スタックで元素DMG+12-24%"
+            ),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "kagura_skill_dmg_stacks",
-                    description: "元素スキル使用でスキルDMG+12-24%（1スタック）、最大3スタック",
+                    description: desc!(
+                        "元素スキル使用でスキルDMG+12-24%（1スタック）、最大3スタック"
+                    ),
                     stat: BuffableStat::SkillDmgBonus,
                     value: 0.12,
                     nightsoul_value: None,
@@ -297,7 +305,7 @@ pub const KAGURAS_VERITY: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "kagura_full_stack_elemental_dmg",
-                    description: "3スタック時に元素DMG+12-24%（DmgBonus近似値、物理除外）",
+                    description: desc!("3スタック時に元素DMG+12-24%（DmgBonus近似値、物理除外）"),
                     stat: BuffableStat::DmgBonus,
                     value: 0.12,
                     nightsoul_value: None,
@@ -321,11 +329,13 @@ pub const LOST_PRAYER_TO_THE_SACRED_WINDS: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Lost Prayer to the Sacred Winds",
         effect: PassiveEffect {
-            description: "フィールド上で4秒毎に元素DMG+8-16%スタック（最大4スタック）",
+            description: desc!("フィールド上で4秒毎に元素DMG+8-16%スタック（最大4スタック）"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "lost_prayer_dmg",
-                description: "フィールド上で4秒毎に元素DMG+8-16%（1スタック）、最大4スタック",
+                description: desc!(
+                    "フィールド上で4秒毎に元素DMG+8-16%（1スタック）、最大4スタック"
+                ),
                 stat: BuffableStat::DmgBonus,
                 value: 0.08,
                 nightsoul_value: None,
@@ -348,12 +358,12 @@ pub const MEMORY_OF_DUST: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Memory of Dust",
         effect: PassiveEffect {
-            description: "攻撃命中でATK+4-8%スタック（最大5）、シールド時は2倍",
+            description: desc!("攻撃命中でATK+4-8%スタック（最大5）、シールド時は2倍"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "memory_of_dust_atk_stacks",
-                    description: "攻撃命中でATK+4-8%（1スタック）、最大5スタック",
+                    description: desc!("攻撃命中でATK+4-8%（1スタック）、最大5スタック"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.04,
                     nightsoul_value: None,
@@ -364,7 +374,7 @@ pub const MEMORY_OF_DUST: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "memory_of_dust_shield_atk_stacks",
-                    description: "シールド時にATKスタック効果2倍分（追加ATK+4-8%/スタック）",
+                    description: desc!("シールド時にATKスタック効果2倍分（追加ATK+4-8%/スタック）"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.04,
                     nightsoul_value: None,
@@ -388,12 +398,12 @@ pub const NIGHTWEAVERS_LOOKING_GLASS: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Nightweaver's Looking Glass",
         effect: PassiveEffect {
-            description: "夜魂消費でNA DMG+16-32%/CA DMG+16-32%",
+            description: desc!("夜魂消費でNA DMG+16-32%/CA DMG+16-32%"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "nightweaver_na_dmg",
-                    description: "夜魂消費でNA DMG+16-32%",
+                    description: desc!("夜魂消費でNA DMG+16-32%"),
                     stat: BuffableStat::NormalAtkDmgBonus,
                     value: 0.16,
                     nightsoul_value: None,
@@ -404,7 +414,7 @@ pub const NIGHTWEAVERS_LOOKING_GLASS: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "nightweaver_ca_dmg",
-                    description: "夜魂消費でCA DMG+16-32%",
+                    description: desc!("夜魂消費でCA DMG+16-32%"),
                     stat: BuffableStat::ChargedAtkDmgBonus,
                     value: 0.16,
                     nightsoul_value: None,
@@ -428,11 +438,11 @@ pub const NOCTURNES_CURTAIN_CALL: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Nocturne's Curtain Call",
         effect: PassiveEffect {
-            description: "元素スキル/爆発命中でDMG+8-16%スタック（最大5スタック）",
+            description: desc!("元素スキル/爆発命中でDMG+8-16%スタック（最大5スタック）"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "nocturne_dmg_stacks",
-                description: "元素スキル/爆発命中でDMG+8-16%（1スタック）、最大5スタック",
+                description: desc!("元素スキル/爆発命中でDMG+8-16%（1スタック）、最大5スタック"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.08,
                 nightsoul_value: None,
@@ -455,11 +465,11 @@ pub const RELIQUARY_OF_TRUTH: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Reliquary of Truth",
         effect: PassiveEffect {
-            description: "元素反応後にDMG+12-36%",
+            description: desc!("元素反応後にDMG+12-36%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "reliquary_truth_dmg",
-                description: "元素反応後にDMG+12-36%",
+                description: desc!("元素反応後にDMG+12-36%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.12,
                 nightsoul_value: None,
@@ -482,7 +492,7 @@ pub const SKYWARD_ATLAS: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Skyward Atlas",
         effect: PassiveEffect {
-            description: "Ele DMG+12-24%。通常攻撃命中時に追加攻撃",
+            description: desc!("Ele DMG+12-24%。通常攻撃命中時に追加攻撃"),
             buffs: &[StatBuff {
                 stat: BuffableStat::DmgBonus,
                 value: 0.12,
@@ -503,11 +513,11 @@ pub const STARCALLERS_WATCH: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Starcaller's Watch",
         effect: PassiveEffect {
-            description: "チームの元素反応でDMG+20-40%",
+            description: desc!("チームの元素反応でDMG+20-40%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "starcaller_dmg",
-                description: "チームが元素反応を起こした後にDMG+20-40%",
+                description: desc!("チームが元素反応を起こした後にDMG+20-40%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.20,
                 nightsoul_value: None,
@@ -530,12 +540,12 @@ pub const SUNNY_MORNING_SLEEP_IN: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Sunny Morning Sleep-In",
         effect: PassiveEffect {
-            description: "元素反応時にATK+14-28%/DMG+18-36%",
+            description: desc!("元素反応時にATK+14-28%/DMG+18-36%"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "sunny_morning_atk",
-                    description: "元素反応時にATK+14-28%",
+                    description: desc!("元素反応時にATK+14-28%"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.14,
                     nightsoul_value: None,
@@ -546,7 +556,7 @@ pub const SUNNY_MORNING_SLEEP_IN: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "sunny_morning_dmg",
-                    description: "元素反応時にDMG+18-36%",
+                    description: desc!("元素反応時にDMG+18-36%"),
                     stat: BuffableStat::DmgBonus,
                     value: 0.18,
                     nightsoul_value: None,
@@ -570,7 +580,7 @@ pub const SURFS_UP: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Surf's Up",
         effect: PassiveEffect {
-            description: "HP+20-40%。通常攻撃DMGスタック効果",
+            description: desc!("HP+20-40%。通常攻撃DMGスタック効果"),
             buffs: &[StatBuff {
                 stat: BuffableStat::HpPercent,
                 value: 0.20,
@@ -578,7 +588,9 @@ pub const SURFS_UP: WeaponData = WeaponData {
             }],
             conditional_buffs: &[ConditionalBuff {
                 name: "surfs_up_na_stacks",
-                description: "夜魂バースト時にNA DMG+10-20%（1スタック/1000HP基準）、最大5スタック",
+                description: desc!(
+                    "夜魂バースト時にNA DMG+10-20%（1スタック/1000HP基準）、最大5スタック"
+                ),
                 stat: BuffableStat::NormalAtkDmgBonus,
                 value: 0.10,
                 nightsoul_value: None,
@@ -601,7 +613,7 @@ pub const TOME_OF_THE_ETERNAL_FLOW: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Tome of the Eternal Flow",
         effect: PassiveEffect {
-            description: "HP+16-32%。HP変動時にCA DMGスタック",
+            description: desc!("HP+16-32%。HP変動時にCA DMGスタック"),
             buffs: &[StatBuff {
                 stat: BuffableStat::HpPercent,
                 value: 0.16,
@@ -609,7 +621,7 @@ pub const TOME_OF_THE_ETERNAL_FLOW: WeaponData = WeaponData {
             }],
             conditional_buffs: &[ConditionalBuff {
                 name: "tome_eternal_flow_ca",
-                description: "HP変動時にCA DMG+14-28%スタック、最大3スタック",
+                description: desc!("HP変動時にCA DMG+14-28%スタック、最大3スタック"),
                 stat: BuffableStat::ChargedAtkDmgBonus,
                 value: 0.14,
                 nightsoul_value: None,
@@ -632,11 +644,13 @@ pub const TULAYTULLAHS_REMEMBRANCE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Tulaytullah's Remembrance",
         effect: PassiveEffect {
-            description: "通常攻撃DMG+4.8-9.6%スタック（最大10スタック、1秒毎）。攻撃速度バフは非対応",
+            description: desc!(
+                "通常攻撃DMG+4.8-9.6%スタック（最大10スタック、1秒毎）。攻撃速度バフは非対応"
+            ),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "tulaytullah_na_dmg_stacks",
-                description: "通常攻撃DMG+4.8-9.6%（1スタック）、最大10スタック",
+                description: desc!("通常攻撃DMG+4.8-9.6%（1スタック）、最大10スタック"),
                 stat: BuffableStat::NormalAtkDmgBonus,
                 value: 0.048,
                 nightsoul_value: None,
@@ -659,11 +673,11 @@ pub const VIVID_NOTIONS: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Vivid Notions",
         effect: PassiveEffect {
-            description: "夜魂バースト時にDMG+8-16%スタック（最大3スタック）",
+            description: desc!("夜魂バースト時にDMG+8-16%スタック（最大3スタック）"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "vivid_notions_dmg_stacks",
-                description: "夜魂バースト時にDMG+8-16%（1スタック）、最大3スタック",
+                description: desc!("夜魂バースト時にDMG+8-16%（1スタック）、最大3スタック"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.08,
                 nightsoul_value: None,
@@ -690,12 +704,12 @@ pub const ASH_GRAVEN_DRINKING_HORN: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Ash-Graven Drinking Horn",
         effect: PassiveEffect {
-            description: "夜魂バースト中に全攻撃にフラットDMG+HP上限の2-4%",
+            description: desc!("夜魂バースト中に全攻撃にフラットDMG+HP上限の2-4%"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "ash_graven_na_hp",
-                    description: "夜魂バースト中に通常攻撃フラットDMG+HP上限の2-4%",
+                    description: desc!("夜魂バースト中に通常攻撃フラットDMG+HP上限の2-4%"),
                     stat: BuffableStat::NormalAtkFlatDmg,
                     value: 0.02,
                     nightsoul_value: None,
@@ -713,7 +727,7 @@ pub const ASH_GRAVEN_DRINKING_HORN: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "ash_graven_ca_hp",
-                    description: "夜魂バースト中に重撃フラットDMG+HP上限の2-4%",
+                    description: desc!("夜魂バースト中に重撃フラットDMG+HP上限の2-4%"),
                     stat: BuffableStat::ChargedAtkFlatDmg,
                     value: 0.02,
                     nightsoul_value: None,
@@ -731,7 +745,7 @@ pub const ASH_GRAVEN_DRINKING_HORN: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "ash_graven_plunge_hp",
-                    description: "夜魂バースト中に落下攻撃フラットDMG+HP上限の2-4%",
+                    description: desc!("夜魂バースト中に落下攻撃フラットDMG+HP上限の2-4%"),
                     stat: BuffableStat::PlungingAtkFlatDmg,
                     value: 0.02,
                     nightsoul_value: None,
@@ -749,7 +763,7 @@ pub const ASH_GRAVEN_DRINKING_HORN: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "ash_graven_skill_hp",
-                    description: "夜魂バースト中に元素スキルフラットDMG+HP上限の2-4%",
+                    description: desc!("夜魂バースト中に元素スキルフラットDMG+HP上限の2-4%"),
                     stat: BuffableStat::SkillFlatDmg,
                     value: 0.02,
                     nightsoul_value: None,
@@ -767,7 +781,7 @@ pub const ASH_GRAVEN_DRINKING_HORN: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "ash_graven_burst_hp",
-                    description: "夜魂バースト中に元素爆発フラットDMG+HP上限の2-4%",
+                    description: desc!("夜魂バースト中に元素爆発フラットDMG+HP上限の2-4%"),
                     stat: BuffableStat::BurstFlatDmg,
                     value: 0.02,
                     nightsoul_value: None,
@@ -798,7 +812,7 @@ pub const BALLAD_OF_THE_BOUNDLESS_BLUE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Ballad of the Boundless Blue",
         effect: PassiveEffect {
-            description: "NA/CA DMG+8-16%",
+            description: desc!("NA/CA DMG+8-16%"),
             buffs: &[
                 StatBuff {
                     stat: BuffableStat::NormalAtkDmgBonus,
@@ -826,11 +840,11 @@ pub const BLACKCLIFF_AGATE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Blackcliff Agate",
         effect: PassiveEffect {
-            description: "Conditional: 敵撃破時にATK%スタック",
+            description: desc!("Conditional: 敵撃破時にATK%スタック"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "blackcliff_agate_atk",
-                description: "敵撃破後にATK+12-24%、最大3スタック",
+                description: desc!("敵撃破後にATK+12-24%、最大3スタック"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.12,
                 nightsoul_value: None,
@@ -853,11 +867,11 @@ pub const BLACKMARROW_LANTERN: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Blackmarrow Lantern",
         effect: PassiveEffect {
-            description: "Conditional: 夜魂ポイント消費でDMGアップ",
+            description: desc!("Conditional: 夜魂ポイント消費でDMGアップ"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "blackmarrow_dmg",
-                description: "夜魂ポイント消費時にDMG+12-24%",
+                description: desc!("夜魂ポイント消費時にDMG+12-24%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.12,
                 nightsoul_value: None,
@@ -880,11 +894,11 @@ pub const DAWNING_FROST: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Dawning Frost",
         effect: PassiveEffect {
-            description: "Conditional: 元素スキル命中でDMGアップ",
+            description: desc!("Conditional: 元素スキル命中でDMGアップ"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "dawning_frost_dmg",
-                description: "元素スキル命中後にDMG+16-32%",
+                description: desc!("元素スキル命中後にDMG+16-32%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.16,
                 nightsoul_value: None,
@@ -907,12 +921,12 @@ pub const DODOCO_TALES: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Dodoco Tales",
         effect: PassiveEffect {
-            description: "Conditional: 通常攻撃命中でCA DMGアップ、CA命中でATKアップ",
+            description: desc!("Conditional: 通常攻撃命中でCA DMGアップ、CA命中でATKアップ"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "dodoco_ca_dmg",
-                    description: "通常攻撃命中時にCA DMG+16-32%",
+                    description: desc!("通常攻撃命中時にCA DMG+16-32%"),
                     stat: BuffableStat::ChargedAtkDmgBonus,
                     value: 0.16,
                     nightsoul_value: None,
@@ -923,7 +937,7 @@ pub const DODOCO_TALES: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "dodoco_atk",
-                    description: "重撃命中時にATK+8-16%",
+                    description: desc!("重撃命中時にATK+8-16%"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.08,
                     nightsoul_value: None,
@@ -947,11 +961,11 @@ pub const ETHERLIGHT_SPINDLELUTE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Etherlight Spindlelute",
         effect: PassiveEffect {
-            description: "Conditional: 元素爆発後にDMGアップ",
+            description: desc!("Conditional: 元素爆発後にDMGアップ"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "etherlight_dmg",
-                description: "元素爆発命中後にDMG+16-32%",
+                description: desc!("元素爆発命中後にDMG+16-32%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.16,
                 nightsoul_value: None,
@@ -974,7 +988,7 @@ pub const EYE_OF_PERCEPTION: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Eye of Perception",
         effect: PassiveEffect {
-            description: "Conditional: 通常/重撃命中時に追加ダメージ弾発射",
+            description: desc!("Conditional: 通常/重撃命中時に追加ダメージ弾発射"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -991,7 +1005,7 @@ pub const FAVONIUS_CODEX: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Favonius Codex",
         effect: PassiveEffect {
-            description: "Conditional: 会心命中時に元素粒子生成",
+            description: desc!("Conditional: 会心命中時に元素粒子生成"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -1008,11 +1022,11 @@ pub const FLOWING_PURITY: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Flowing Purity",
         effect: PassiveEffect {
-            description: "Conditional: HP消費時にDMGアップ、治療効果でバフ延長",
+            description: desc!("Conditional: HP消費時にDMGアップ、治療効果でバフ延長"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "flowing_purity_dmg",
-                description: "HP増減時にDMG+8-16%",
+                description: desc!("HP増減時にDMG+8-16%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.08,
                 nightsoul_value: None,
@@ -1035,7 +1049,9 @@ pub const FROSTBEARER: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Frostbearer",
         effect: PassiveEffect {
-            description: "Conditional: 通常/重撃命中時に氷柱ダメージ、氷/凍結時にダメージ増加",
+            description: desc!(
+                "Conditional: 通常/重撃命中時に氷柱ダメージ、氷/凍結時にダメージ増加"
+            ),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -1052,11 +1068,13 @@ pub const FRUIT_OF_FULFILLMENT: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Fruit of Fulfillment",
         effect: PassiveEffect {
-            description: "Conditional: 元素反応時にEM獲得/ATK減少スタック",
+            description: desc!("Conditional: 元素反応時にEM獲得/ATK減少スタック"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "fruit_of_fulfillment_em",
-                description: "元素反応発動時にEM+24-48スタック（最大5スタック）。ATK減少は非対応",
+                description: desc!(
+                    "元素反応発動時にEM+24-48スタック（最大5スタック）。ATK減少は非対応"
+                ),
                 stat: BuffableStat::ElementalMastery,
                 value: 24.0,
                 nightsoul_value: None,
@@ -1079,11 +1097,11 @@ pub const HAKUSHIN_RING: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Hakushin Ring",
         effect: PassiveEffect {
-            description: "Conditional: 雷元素反応時に関連元素のDMGアップ",
+            description: desc!("Conditional: 雷元素反応時に関連元素のDMGアップ"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "hakushin_ring_elem_dmg",
-                description: "雷元素反応発動後、関連元素DMG+10-20%（チームメンバーも対象）",
+                description: desc!("雷元素反応発動後、関連元素DMG+10-20%（チームメンバーも対象）"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.10,
                 nightsoul_value: None,
@@ -1106,11 +1124,11 @@ pub const MAPPA_MARE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Mappa Mare",
         effect: PassiveEffect {
-            description: "元素反応発動後に元素DMG+8-16%スタック（最大2スタック、10秒）",
+            description: desc!("元素反応発動後に元素DMG+8-16%スタック（最大2スタック、10秒）"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "mappa_mare_dmg",
-                description: "元素反応後に元素DMG+8-16%（1スタック）、最大2スタック",
+                description: desc!("元素反応後に元素DMG+8-16%（1スタック）、最大2スタック"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.08,
                 nightsoul_value: None,
@@ -1133,11 +1151,11 @@ pub const OATHSWORN_EYE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Oathsworn Eye",
         effect: PassiveEffect {
-            description: "Conditional: 元素スキル使用後にER+24%",
+            description: desc!("Conditional: 元素スキル使用後にER+24%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "oathsworn_eye_er",
-                description: "元素スキル使用後にER+24-48%",
+                description: desc!("元素スキル使用後にER+24-48%"),
                 stat: BuffableStat::EnergyRecharge,
                 value: 0.24,
                 nightsoul_value: None,
@@ -1160,7 +1178,7 @@ pub const PROTOTYPE_AMBER: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Prototype Amber",
         effect: PassiveEffect {
-            description: "Conditional: 元素爆発使用後にHP回復とエネルギー回復",
+            description: desc!("Conditional: 元素爆発使用後にHP回復とエネルギー回復"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -1177,11 +1195,11 @@ pub const RING_OF_YAXCHE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Ring of Yaxche",
         effect: PassiveEffect {
-            description: "夜魂バースト中にNA DMG+HP上限の2-4%",
+            description: desc!("夜魂バースト中にNA DMG+HP上限の2-4%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "ring_of_yaxche_na_hp",
-                description: "夜魂バースト中にNA DMG+HP上限の2-4%（フラットダメージ）",
+                description: desc!("夜魂バースト中にNA DMG+HP上限の2-4%（フラットダメージ）"),
                 stat: BuffableStat::NormalAtkFlatDmg,
                 value: 0.02,
                 nightsoul_value: None,
@@ -1211,11 +1229,13 @@ pub const ROYAL_GRIMOIRE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Royal Grimoire",
         effect: PassiveEffect {
-            description: "Conditional: ダメージ時にCRIT Rate+8%スタック、会心時リセット",
+            description: desc!("Conditional: ダメージ時にCRIT Rate+8%スタック、会心時リセット"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "royal_grimoire_cr",
-                description: "ダメージ時にCRIT Rate+8-16%、最大5スタック（会心命中でリセット）",
+                description: desc!(
+                    "ダメージ時にCRIT Rate+8-16%、最大5スタック（会心命中でリセット）"
+                ),
                 stat: BuffableStat::CritRate,
                 value: 0.08,
                 nightsoul_value: None,
@@ -1238,7 +1258,7 @@ pub const SACRIFICIAL_FRAGMENTS: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Sacrificial Fragments",
         effect: PassiveEffect {
-            description: "Conditional: 元素スキル命中時にCD即リセット",
+            description: desc!("Conditional: 元素スキル命中時にCD即リセット"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -1255,12 +1275,12 @@ pub const SACRIFICIAL_JADE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Sacrificial Jade",
         effect: PassiveEffect {
-            description: "Conditional: フィールドに出た時にHP%/EM獲得",
+            description: desc!("Conditional: フィールドに出た時にHP%/EM獲得"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "sacrificial_jade_hp",
-                    description: "フィールドに出た時にHP+32-64%",
+                    description: desc!("フィールドに出た時にHP+32-64%"),
                     stat: BuffableStat::HpPercent,
                     value: 0.32,
                     nightsoul_value: None,
@@ -1271,7 +1291,7 @@ pub const SACRIFICIAL_JADE: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "sacrificial_jade_em",
-                    description: "フィールドに出た時にEM+40-80",
+                    description: desc!("フィールドに出た時にEM+40-80"),
                     stat: BuffableStat::ElementalMastery,
                     value: 40.0,
                     nightsoul_value: None,
@@ -1295,12 +1315,14 @@ pub const SOLAR_PEARL: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Solar Pearl",
         effect: PassiveEffect {
-            description: "Conditional: NA命中でSkill/Burst DMGアップ、Skill/Burst命中でNA DMGアップ",
+            description: desc!(
+                "Conditional: NA命中でSkill/Burst DMGアップ、Skill/Burst命中でNA DMGアップ"
+            ),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "solar_pearl_skill_dmg",
-                    description: "通常攻撃命中後にSkill DMG+20-40%",
+                    description: desc!("通常攻撃命中後にSkill DMG+20-40%"),
                     stat: BuffableStat::SkillDmgBonus,
                     value: 0.20,
                     nightsoul_value: None,
@@ -1311,7 +1333,7 @@ pub const SOLAR_PEARL: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "solar_pearl_burst_dmg",
-                    description: "通常攻撃命中後にBurst DMG+20-40%",
+                    description: desc!("通常攻撃命中後にBurst DMG+20-40%"),
                     stat: BuffableStat::BurstDmgBonus,
                     value: 0.20,
                     nightsoul_value: None,
@@ -1322,7 +1344,7 @@ pub const SOLAR_PEARL: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "solar_pearl_na_dmg",
-                    description: "元素スキル/爆発命中後にNA DMG+20-40%",
+                    description: desc!("元素スキル/爆発命中後にNA DMG+20-40%"),
                     stat: BuffableStat::NormalAtkDmgBonus,
                     value: 0.20,
                     nightsoul_value: None,
@@ -1346,12 +1368,12 @@ pub const THE_WIDSITH: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "The Widsith",
         effect: PassiveEffect {
-            description: "Conditional: フィールドに出た時にランダムバフ（ATK%/元素DMG/EM）",
+            description: desc!("Conditional: フィールドに出た時にランダムバフ（ATK%/元素DMG/EM）"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "widsith_atk",
-                    description: "登場時にランダム: ATK+60-120%",
+                    description: desc!("登場時にランダム: ATK+60-120%"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.60,
                     nightsoul_value: None,
@@ -1362,7 +1384,7 @@ pub const THE_WIDSITH: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "widsith_dmg",
-                    description: "登場時にランダム: 全元素DMG+48-96%",
+                    description: desc!("登場時にランダム: 全元素DMG+48-96%"),
                     stat: BuffableStat::DmgBonus,
                     value: 0.48,
                     nightsoul_value: None,
@@ -1373,7 +1395,7 @@ pub const THE_WIDSITH: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "widsith_em",
-                    description: "登場時にランダム: EM+240-480",
+                    description: desc!("登場時にランダム: EM+240-480"),
                     stat: BuffableStat::ElementalMastery,
                     value: 240.0,
                     nightsoul_value: None,
@@ -1397,12 +1419,12 @@ pub const WANDERING_EVENSTAR: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Wandering Evenstar",
         effect: PassiveEffect {
-            description: "Conditional: EM基準でATKアップ、チームにも付与",
+            description: desc!("Conditional: EM基準でATKアップ、チームにも付与"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "wandering_evenstar_atk",
-                    description: "スキル使用後: EM×0.24-0.48分をATKフラットに加算",
+                    description: desc!("スキル使用後: EM×0.24-0.48分をATKフラットに加算"),
                     stat: BuffableStat::AtkFlat,
                     value: 0.24,
                     nightsoul_value: None,
@@ -1420,7 +1442,9 @@ pub const WANDERING_EVENSTAR: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "wandering_evenstar_team_atk",
-                    description: "スキル使用後: EM×0.072-0.144分をチームメンバーのATKフラットに加算（30%）",
+                    description: desc!(
+                        "スキル使用後: EM×0.072-0.144分をチームメンバーのATKフラットに加算（30%）"
+                    ),
                     stat: BuffableStat::AtkFlat,
                     value: 0.072,
                     nightsoul_value: None,
@@ -1451,11 +1475,11 @@ pub const WAVERIDING_WHIRL: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Waveriding Whirl",
         effect: PassiveEffect {
-            description: "Conditional: 元素反応時にEMアップ",
+            description: desc!("Conditional: 元素反応時にEMアップ"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "waveriding_whirl_em",
-                description: "元素反応発動時にEM+24-48",
+                description: desc!("元素反応発動時にEM+24-48"),
                 stat: BuffableStat::ElementalMastery,
                 value: 24.0,
                 nightsoul_value: None,
@@ -1478,11 +1502,11 @@ pub const WINE_AND_SONG: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Wine and Song",
         effect: PassiveEffect {
-            description: "Conditional: ダッシュ後にATKアップ",
+            description: desc!("Conditional: ダッシュ後にATKアップ"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "wine_and_song_atk",
-                description: "ダッシュ後にATK+20-40%",
+                description: desc!("ダッシュ後にATK+20-40%"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.20,
                 nightsoul_value: None,
@@ -1509,11 +1533,11 @@ pub const EMERALD_ORB: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Emerald Orb",
         effect: PassiveEffect {
-            description: "水元素反応トリガー後10秒間ATK+20-40%",
+            description: desc!("水元素反応トリガー後10秒間ATK+20-40%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "emerald_orb_atk",
-                description: "水元素反応トリガー後10秒間ATK+20-40%",
+                description: desc!("水元素反応トリガー後10秒間ATK+20-40%"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.20,
                 nightsoul_value: None,
@@ -1536,11 +1560,11 @@ pub const MAGIC_GUIDE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Magic Guide",
         effect: PassiveEffect {
-            description: "Conditional: 水/雷の影響を受けた敵にDMG+12%",
+            description: desc!("Conditional: 水/雷の影響を受けた敵にDMG+12%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "magic_guide_dmg",
-                description: "水/雷の影響を受けた敵へのDMG+12-24%",
+                description: desc!("水/雷の影響を受けた敵へのDMG+12-24%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.12,
                 nightsoul_value: None,
@@ -1563,7 +1587,7 @@ pub const OTHERWORLDLY_STORY: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Otherworldly Story",
         effect: PassiveEffect {
-            description: "Conditional: 元素オーブ/粒子獲得時にHP回復",
+            description: desc!("Conditional: 元素オーブ/粒子獲得時にHP回復"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -1580,11 +1604,11 @@ pub const THRILLING_TALES_OF_DRAGON_SLAYERS: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Thrilling Tales of Dragon Slayers",
         effect: PassiveEffect {
-            description: "Conditional: キャラ交代時に次のキャラのATK+24%",
+            description: desc!("Conditional: キャラ交代時に次のキャラのATK+24%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "ttds_team_atk",
-                description: "キャラ交代時、次の出場キャラATK+24-48%",
+                description: desc!("キャラ交代時、次の出場キャラATK+24-48%"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.24,
                 nightsoul_value: None,
@@ -1607,11 +1631,11 @@ pub const TWIN_NEPHRITE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Twin Nephrite",
         effect: PassiveEffect {
-            description: "敵撃破後10秒間ATK+12-24%",
+            description: desc!("敵撃破後10秒間ATK+12-24%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "twin_nephrite_atk",
-                description: "敵撃破後10秒間ATK+12-24%",
+                description: desc!("敵撃破後10秒間ATK+12-24%"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.12,
                 nightsoul_value: None,

--- a/crates/data/src/weapons/claymore.rs
+++ b/crates/data/src/weapons/claymore.rs
@@ -18,12 +18,12 @@ pub const A_THOUSAND_BLAZING_SUNS: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "A Thousand Blazing Suns",
         effect: PassiveEffect {
-            description: "重撃命中→ATK+28-56%。HP減少→CRIT DMG+20-40%",
+            description: desc!("重撃命中→ATK+28-56%。HP減少→CRIT DMG+20-40%"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "thousand_suns_atk",
-                    description: "重撃命中時にATK+28-56%",
+                    description: desc!("重撃命中時にATK+28-56%"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.28,
                     nightsoul_value: None,
@@ -34,7 +34,7 @@ pub const A_THOUSAND_BLAZING_SUNS: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "thousand_suns_critdmg",
-                    description: "HP減少時にCRIT DMG+20-40%",
+                    description: desc!("HP減少時にCRIT DMG+20-40%"),
                     stat: BuffableStat::CritDmg,
                     value: 0.20,
                     nightsoul_value: None,
@@ -58,12 +58,12 @@ pub const BEACON_OF_THE_REED_SEA: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Beacon of the Reed Sea",
         effect: PassiveEffect {
-            description: "スキル命中後ATK+20-40%、被弾後ATK+20-40%、シールド時HP+32-64%",
+            description: desc!("スキル命中後ATK+20-40%、被弾後ATK+20-40%、シールド時HP+32-64%"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "beacon_skill_atk",
-                    description: "元素スキル命中後にATK+20-40%",
+                    description: desc!("元素スキル命中後にATK+20-40%"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.20,
                     nightsoul_value: None,
@@ -74,7 +74,7 @@ pub const BEACON_OF_THE_REED_SEA: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "beacon_dmg_taken_atk",
-                    description: "ダメージを受けた後にATK+20-40%",
+                    description: desc!("ダメージを受けた後にATK+20-40%"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.20,
                     nightsoul_value: None,
@@ -85,7 +85,7 @@ pub const BEACON_OF_THE_REED_SEA: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "beacon_shield_hp",
-                    description: "シールド保護時にHP+32-64%",
+                    description: desc!("シールド保護時にHP+32-64%"),
                     stat: BuffableStat::HpPercent,
                     value: 0.32,
                     nightsoul_value: None,
@@ -109,11 +109,15 @@ pub const FANG_OF_THE_MOUNTAIN_KING: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Fang of the Mountain King",
         effect: PassiveEffect {
-            description: "元素スキル命中でDMG+10-20%スタック（最大3スタック）。DmgBonus近似値（実際は全元素DMG、物理除外）",
+            description: desc!(
+                "元素スキル命中でDMG+10-20%スタック（最大3スタック）。DmgBonus近似値（実際は全元素DMG、物理除外）"
+            ),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "fang_mountain_king_elemental_dmg_stacks",
-                description: "元素スキル命中でDMG+10-20%（1スタック）、最大3スタック（DmgBonus近似値、物理除外）",
+                description: desc!(
+                    "元素スキル命中でDMG+10-20%（1スタック）、最大3スタック（DmgBonus近似値、物理除外）"
+                ),
                 stat: BuffableStat::DmgBonus,
                 value: 0.10,
                 nightsoul_value: None,
@@ -136,13 +140,17 @@ pub const GEST_OF_THE_MIGHTY_WOLF: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "不屈の騎士道",
         effect: PassiveEffect {
-            description: "ATK SPD+10%。通常/スキル/重撃でFour Winds' Hymnスタック獲得(最大4)。\
-                スタックごとにDMG+7.5-15.5%。Hexerei: Secret Rite時、スタックごとにCRIT DMGも同値増加",
+            description: desc!(
+                "ATK SPD+10%。通常/スキル/重撃でFour Winds' Hymnスタック獲得(最大4)。\
+                スタックごとにDMG+7.5-15.5%。Hexerei: Secret Rite時、スタックごとにCRIT DMGも同値増加"
+            ),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "gest_mighty_wolf_hymn_dmg",
-                    description: "Four Winds' Hymn: スタックごとにDMG+7.5-15.5%（最大4スタック）",
+                    description: desc!(
+                        "Four Winds' Hymn: スタックごとにDMG+7.5-15.5%（最大4スタック）"
+                    ),
                     stat: BuffableStat::DmgBonus,
                     value: 0.075,
                     nightsoul_value: None,
@@ -153,7 +161,9 @@ pub const GEST_OF_THE_MIGHTY_WOLF: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "gest_mighty_wolf_hymn_hexerei_crit",
-                    description: "Hexerei: Secret Rite時、Four Winds' HymnスタックごとにCRIT DMG+7.5-15.5%",
+                    description: desc!(
+                        "Hexerei: Secret Rite時、Four Winds' HymnスタックごとにCRIT DMG+7.5-15.5%"
+                    ),
                     stat: BuffableStat::CritDmg,
                     value: 0.075,
                     nightsoul_value: None,
@@ -177,7 +187,7 @@ pub const REDHORN_STONETHRESHER: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "赤角の石塵滅砕",
         effect: PassiveEffect {
-            description: "DEF+28-56%。通常攻撃と重撃にDEF基準の追加ダメージ",
+            description: desc!("DEF+28-56%。通常攻撃と重撃にDEF基準の追加ダメージ"),
             buffs: &[StatBuff {
                 stat: BuffableStat::DefPercent,
                 value: 0.28,
@@ -186,7 +196,7 @@ pub const REDHORN_STONETHRESHER: WeaponData = WeaponData {
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "redhorn_def_normal_flat",
-                    description: "DEF×40-80%分を通常攻撃フラットダメージに加算",
+                    description: desc!("DEF×40-80%分を通常攻撃フラットダメージに加算"),
                     stat: BuffableStat::NormalAtkFlatDmg,
                     value: 0.40,
                     nightsoul_value: None,
@@ -201,7 +211,7 @@ pub const REDHORN_STONETHRESHER: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "redhorn_def_charged_flat",
-                    description: "DEF×40-80%分を重撃フラットダメージに加算",
+                    description: desc!("DEF×40-80%分を重撃フラットダメージに加算"),
                     stat: BuffableStat::ChargedAtkFlatDmg,
                     value: 0.40,
                     nightsoul_value: None,
@@ -229,7 +239,7 @@ pub const SKYWARD_PRIDE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "天空の矜持",
         effect: PassiveEffect {
-            description: "DMG+8-16%。元素爆発後に真空の刃で追加ダメージ",
+            description: desc!("DMG+8-16%。元素爆発後に真空の刃で追加ダメージ"),
             buffs: &[StatBuff {
                 stat: BuffableStat::DmgBonus,
                 value: 0.08,
@@ -252,7 +262,7 @@ pub const SONG_OF_BROKEN_PINES: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "千年の大楽章・揺らぎ無き心",
         effect: PassiveEffect {
-            description: "ATK+16-32%。印4蓄積でチーム全員ATK+20-40%/通常ATK速度アップ",
+            description: desc!("ATK+16-32%。印4蓄積でチーム全員ATK+20-40%/通常ATK速度アップ"),
             buffs: &[StatBuff {
                 stat: BuffableStat::AtkPercent,
                 value: 0.16,
@@ -261,7 +271,7 @@ pub const SONG_OF_BROKEN_PINES: WeaponData = WeaponData {
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "song_broken_pines_team_atk",
-                    description: "印4蓄積時にチーム全員ATK+20-40%",
+                    description: desc!("印4蓄積時にチーム全員ATK+20-40%"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.20,
                     nightsoul_value: None,
@@ -272,7 +282,7 @@ pub const SONG_OF_BROKEN_PINES: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "song_broken_pines_team_normal_dmg",
-                    description: "印4蓄積時にチーム全員通常攻撃DMG+12-24%",
+                    description: desc!("印4蓄積時にチーム全員通常攻撃DMG+12-24%"),
                     stat: BuffableStat::NormalAtkDmgBonus,
                     value: 0.12,
                     nightsoul_value: None,
@@ -296,12 +306,12 @@ pub const THE_UNFORGED: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "金璋の剣",
         effect: PassiveEffect {
-            description: "攻撃命中でATK+4-8%スタック（最大5）、シールド時は2倍",
+            description: desc!("攻撃命中でATK+4-8%スタック（最大5）、シールド時は2倍"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "the_unforged_atk_stacks",
-                    description: "攻撃命中でATK+4-8%（1スタック）、最大5スタック",
+                    description: desc!("攻撃命中でATK+4-8%（1スタック）、最大5スタック"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.04,
                     nightsoul_value: None,
@@ -312,7 +322,7 @@ pub const THE_UNFORGED: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "the_unforged_shield_atk_stacks",
-                    description: "シールド時にATKスタック効果2倍分（追加ATK+4-8%/スタック）",
+                    description: desc!("シールド時にATKスタック効果2倍分（追加ATK+4-8%/スタック）"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.04,
                     nightsoul_value: None,
@@ -336,7 +346,9 @@ pub const VERDICT: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "裁定",
         effect: PassiveEffect {
-            description: "Skill DMG+18-36%。シールド保護中スタック獲得でさらにSkill DMG+18-36%/スタック（最大2）",
+            description: desc!(
+                "Skill DMG+18-36%。シールド保護中スタック獲得でさらにSkill DMG+18-36%/スタック（最大2）"
+            ),
             buffs: &[StatBuff {
                 stat: BuffableStat::SkillDmgBonus,
                 value: 0.18,
@@ -344,7 +356,7 @@ pub const VERDICT: WeaponData = WeaponData {
             }],
             conditional_buffs: &[ConditionalBuff {
                 name: "verdict_skill_dmg_stacks",
-                description: "シールド保護中スタック毎にSkill DMG+18-36%（最大2スタック）",
+                description: desc!("シールド保護中スタック毎にSkill DMG+18-36%（最大2スタック）"),
                 stat: BuffableStat::SkillDmgBonus,
                 value: 0.18,
                 nightsoul_value: None,
@@ -367,7 +379,9 @@ pub const WOLFS_GRAVESTONE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "止めの一撃",
         effect: PassiveEffect {
-            description: "ATK+20-40%。HP30%以下の敵を攻撃するとチーム全員ATK+40-80%、12秒、30秒に1回",
+            description: desc!(
+                "ATK+20-40%。HP30%以下の敵を攻撃するとチーム全員ATK+40-80%、12秒、30秒に1回"
+            ),
             buffs: &[StatBuff {
                 stat: BuffableStat::AtkPercent,
                 value: 0.20,
@@ -375,7 +389,7 @@ pub const WOLFS_GRAVESTONE: WeaponData = WeaponData {
             }],
             conditional_buffs: &[ConditionalBuff {
                 name: "wolfs_gravestone_team_atk",
-                description: "HP30%以下の敵に命中時、チーム全員ATK+40-80%（12秒）",
+                description: desc!("HP30%以下の敵に命中時、チーム全員ATK+40-80%（12秒）"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.40,
                 nightsoul_value: None,
@@ -402,11 +416,15 @@ pub const AKUOUMARU: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "曚雲の海鯨波",
         effect: PassiveEffect {
-            description: "チーム総エネルギー上限に応じてBurst DMGアップ（最大Burst DMG+40-80%、総EP280超時）",
+            description: desc!(
+                "チーム総エネルギー上限に応じてBurst DMGアップ（最大Burst DMG+40-80%、総EP280超時）"
+            ),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "akuoumaru_burst_dmg",
-                description: "チーム総エネルギー上限に応じてBurst DMG+最大40-80%（280EP基準）",
+                description: desc!(
+                    "チーム総エネルギー上限に応じてBurst DMG+最大40-80%（280EP基準）"
+                ),
                 stat: BuffableStat::BurstDmgBonus,
                 value: 0.40,
                 nightsoul_value: None,
@@ -429,11 +447,11 @@ pub const BLACKCLIFF_SLASHER: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "追撃の一撃",
         effect: PassiveEffect {
-            description: "敵を倒すとATK+12-24%（1スタック）、30秒、最大3スタック",
+            description: desc!("敵を倒すとATK+12-24%（1スタック）、30秒、最大3スタック"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "blackcliff_slasher_atk_stacks",
-                description: "敵撃破毎にATK+12-24%（1スタック）、最大3スタック",
+                description: desc!("敵撃破毎にATK+12-24%（1スタック）、最大3スタック"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.12,
                 nightsoul_value: None,
@@ -456,11 +474,11 @@ pub const EARTH_SHAKER: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Earth Shaker",
         effect: PassiveEffect {
-            description: "Conditional: 元素スキル命中で元素爆発ダメージアップ",
+            description: desc!("Conditional: 元素スキル命中で元素爆発ダメージアップ"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "earth_shaker_burst_dmg",
-                description: "元素スキル命中後にBurst DMG+16-32%",
+                description: desc!("元素スキル命中後にBurst DMG+16-32%"),
                 stat: BuffableStat::BurstDmgBonus,
                 value: 0.16,
                 nightsoul_value: None,
@@ -483,7 +501,7 @@ pub const FAVONIUS_GREATSWORD: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "西風の息吹",
         effect: PassiveEffect {
-            description: "Conditional: 会心命中時に元素粒子を生成、12-6秒に1回",
+            description: desc!("Conditional: 会心命中時に元素粒子を生成、12-6秒に1回"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -500,11 +518,11 @@ pub const FLAME_FORGED_INSIGHT: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Flame-Forged Insight",
         effect: PassiveEffect {
-            description: "元素反応を発生させるとDMG+16-32%（12秒）",
+            description: desc!("元素反応を発生させるとDMG+16-32%（12秒）"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "flame_forged_insight_dmg",
-                description: "元素反応発生後にDMG+16-32%",
+                description: desc!("元素反応発生後にDMG+16-32%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.16,
                 nightsoul_value: None,
@@ -527,11 +545,11 @@ pub const FOREST_REGALIA: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "森林の瑞祥",
         effect: PassiveEffect {
-            description: "草元素反応発動後に種を生成。種を取得するとEM+60-120（12秒）",
+            description: desc!("草元素反応発動後に種を生成。種を取得するとEM+60-120（12秒）"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "forest_regalia_em",
-                description: "草元素反応後の種取得でEM+60-120",
+                description: desc!("草元素反応後の種取得でEM+60-120"),
                 stat: BuffableStat::ElementalMastery,
                 value: 60.0,
                 nightsoul_value: None,
@@ -554,7 +572,7 @@ pub const FRUITFUL_HOOK: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Fruitful Hook",
         effect: PassiveEffect {
-            description: "Conditional: 落下攻撃命中で追加ダメージ",
+            description: desc!("Conditional: 落下攻撃命中で追加ダメージ"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -571,7 +589,7 @@ pub const KATSURAGIKIRI_NAGAMASA: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "名刀・廻りの灯",
         effect: PassiveEffect {
-            description: "Skill DMG+6-12%。スキル命中で元素エネルギー消費後に回復",
+            description: desc!("Skill DMG+6-12%。スキル命中で元素エネルギー消費後に回復"),
             buffs: &[StatBuff {
                 stat: BuffableStat::SkillDmgBonus,
                 value: 0.06,
@@ -592,12 +610,12 @@ pub const LITHIC_BLADE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "千岩の刃",
         effect: PassiveEffect {
-            description: "Conditional: チーム内の璃月キャラ人数に応じてATK/CRIT Rateアップ",
+            description: desc!("Conditional: チーム内の璃月キャラ人数に応じてATK/CRIT Rateアップ"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "lithic_blade_atk",
-                    description: "璃月キャラ1人につきATK+7-11%",
+                    description: desc!("璃月キャラ1人につきATK+7-11%"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.07,
                     nightsoul_value: None,
@@ -610,7 +628,7 @@ pub const LITHIC_BLADE: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "lithic_blade_crit",
-                    description: "璃月キャラ1人につきCR+3-7%",
+                    description: desc!("璃月キャラ1人につきCR+3-7%"),
                     stat: BuffableStat::CritRate,
                     value: 0.03,
                     nightsoul_value: None,
@@ -636,7 +654,7 @@ pub const LUXURIOUS_SEA_LORD: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "海獣の宴",
         effect: PassiveEffect {
-            description: "Burst DMG+12-24%。元素爆発命中時にマグロを召喚して追加ダメージ",
+            description: desc!("Burst DMG+12-24%。元素爆発命中時にマグロを召喚して追加ダメージ"),
             buffs: &[StatBuff {
                 stat: BuffableStat::BurstDmgBonus,
                 value: 0.12,
@@ -657,12 +675,12 @@ pub const MAILED_FLOWER: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Mailed Flower",
         effect: PassiveEffect {
-            description: "元素スキル/元素爆発命中後にATK+12-24%/EM+48-96（8秒）",
+            description: desc!("元素スキル/元素爆発命中後にATK+12-24%/EM+48-96（8秒）"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "mailed_flower_atk",
-                    description: "スキル/爆発命中後にATK+12-24%",
+                    description: desc!("スキル/爆発命中後にATK+12-24%"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.12,
                     nightsoul_value: None,
@@ -673,7 +691,7 @@ pub const MAILED_FLOWER: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "mailed_flower_em",
-                    description: "スキル/爆発命中後にEM+48-96",
+                    description: desc!("スキル/爆発命中後にEM+48-96"),
                     stat: BuffableStat::ElementalMastery,
                     value: 48.0,
                     nightsoul_value: None,
@@ -697,12 +715,14 @@ pub const MAKHAIRA_AQUAMARINE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "砂海の渡し守",
         effect: PassiveEffect {
-            description: "EM×0.024-0.048%分のATK(フラット)を自身に付与。その30%をチームメンバーにも付与",
+            description: desc!(
+                "EM×0.024-0.048%分のATK(フラット)を自身に付与。その30%をチームメンバーにも付与"
+            ),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "makhaira_self_atk",
-                    description: "EM×0.024-0.048%分のATK(フラット)を自身に付与",
+                    description: desc!("EM×0.024-0.048%分のATK(フラット)を自身に付与"),
                     stat: BuffableStat::AtkFlat,
                     value: 0.00024,
                     nightsoul_value: None,
@@ -717,7 +737,7 @@ pub const MAKHAIRA_AQUAMARINE: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "makhaira_team_atk",
-                    description: "自身のATK付与量の30%をチームメンバーに付与",
+                    description: desc!("自身のATK付与量の30%をチームメンバーに付与"),
                     stat: BuffableStat::AtkFlat,
                     value: 0.000072,
                     nightsoul_value: None,
@@ -745,11 +765,11 @@ pub const MASTER_KEY: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Master Key",
         effect: PassiveEffect {
-            description: "Conditional: 元素スキル使用後にEMアップ",
+            description: desc!("Conditional: 元素スキル使用後にEMアップ"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "master_key_em",
-                description: "元素スキル命中後にEM+36-72",
+                description: desc!("元素スキル命中後にEM+36-72"),
                 stat: BuffableStat::ElementalMastery,
                 value: 36.0,
                 nightsoul_value: None,
@@ -772,11 +792,11 @@ pub const PORTABLE_POWER_SAW: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Portable Power Saw",
         effect: PassiveEffect {
-            description: "アークアイテム消費毎にEM+40-80（1スタック）、最大3スタック",
+            description: desc!("アークアイテム消費毎にEM+40-80（1スタック）、最大3スタック"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "portable_power_saw_em_stacks",
-                description: "アークアイテム消費毎にEM+40-80（1スタック）、最大3スタック",
+                description: desc!("アークアイテム消費毎にEM+40-80（1スタック）、最大3スタック"),
                 stat: BuffableStat::ElementalMastery,
                 value: 40.0,
                 nightsoul_value: None,
@@ -799,7 +819,7 @@ pub const PROTOTYPE_ARCHAIC: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "砕石",
         effect: PassiveEffect {
-            description: "Conditional: 通常/重撃命中時に追加ATK範囲ダメージ、15秒に1回",
+            description: desc!("Conditional: 通常/重撃命中時に追加ATK範囲ダメージ、15秒に1回"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -816,11 +836,11 @@ pub const RAINSLASHER: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "雷電の止め",
         effect: PassiveEffect {
-            description: "水/雷元素影響下の敵へのDMG+20-36%",
+            description: desc!("水/雷元素影響下の敵へのDMG+20-36%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "rainslasher_dmg",
-                description: "水/雷元素影響下の敵に対してDMG+20-36%",
+                description: desc!("水/雷元素影響下の敵に対してDMG+20-36%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.20,
                 nightsoul_value: None,
@@ -843,11 +863,13 @@ pub const ROYAL_GREATSWORD: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "集中",
         effect: PassiveEffect {
-            description: "ダメージを与える毎にCRIT Rate+8-16%（1スタック）、最大5スタック。会心発生でリセット",
+            description: desc!(
+                "ダメージを与える毎にCRIT Rate+8-16%（1スタック）、最大5スタック。会心発生でリセット"
+            ),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "royal_greatsword_crit_rate_stacks",
-                description: "ダメージ毎にCRIT Rate+8-16%（1スタック）、最大5スタック",
+                description: desc!("ダメージ毎にCRIT Rate+8-16%（1スタック）、最大5スタック"),
                 stat: BuffableStat::CritRate,
                 value: 0.08,
                 nightsoul_value: None,
@@ -870,7 +892,7 @@ pub const SACRIFICIAL_GREATSWORD: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "祭礼",
         effect: PassiveEffect {
-            description: "Conditional: スキルがダメージを与えるとCD即リセット、30-16秒に1回",
+            description: desc!("Conditional: スキルがダメージを与えるとCD即リセット、30-16秒に1回"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -887,11 +909,13 @@ pub const SERPENT_SPINE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "波乱",
         effect: PassiveEffect {
-            description: "4秒毎にDMG+6-10%スタック（最大5スタック）。ダメージを受けるとスタック減少",
+            description: desc!(
+                "4秒毎にDMG+6-10%スタック（最大5スタック）。ダメージを受けるとスタック減少"
+            ),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "serpent_spine_dmg",
-                description: "フィールド上で4秒毎にDMG+6-10%（1スタック分）、最大5スタック",
+                description: desc!("フィールド上で4秒毎にDMG+6-10%（1スタック分）、最大5スタック"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.06,
                 nightsoul_value: None,
@@ -916,7 +940,9 @@ pub const SNOW_TOMBED_STARSILVER: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "霜葬の星銀",
         effect: PassiveEffect {
-            description: "Conditional: 通常/重撃命中時に氷柱落下、氷元素影響下の敵には追加ダメージ",
+            description: desc!(
+                "Conditional: 通常/重撃命中時に氷柱落下、氷元素影響下の敵には追加ダメージ"
+            ),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -933,12 +959,14 @@ pub const TALKING_STICK: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Talking Stick",
         effect: PassiveEffect {
-            description: "炎/水/氷/雷反応→Ele DMG+16-32%（炎/水/氷/雷）。風/岩/草反応→ATK+20-40%",
+            description: desc!(
+                "炎/水/氷/雷反応→Ele DMG+16-32%（炎/水/氷/雷）。風/岩/草反応→ATK+20-40%"
+            ),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "talking_stick_ele_dmg",
-                    description: "炎/水/氷/雷反応発生時に該当元素DMG+16-32%",
+                    description: desc!("炎/水/氷/雷反応発生時に該当元素DMG+16-32%"),
                     stat: BuffableStat::DmgBonus,
                     value: 0.16,
                     nightsoul_value: None,
@@ -949,7 +977,7 @@ pub const TALKING_STICK: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "talking_stick_atk",
-                    description: "風/岩/草反応発生時にATK+20-40%",
+                    description: desc!("風/岩/草反応発生時にATK+20-40%"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.20,
                     nightsoul_value: None,
@@ -973,11 +1001,13 @@ pub const THE_BELL: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "反響の金鐘",
         effect: PassiveEffect {
-            description: "ダメージを受けるとシールド生成（45秒CD）。シールド保護中にDMG+12-24%",
+            description: desc!(
+                "ダメージを受けるとシールド生成（45秒CD）。シールド保護中にDMG+12-24%"
+            ),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "the_bell_shield_dmg",
-                description: "シールド保護中にDMG+12-24%",
+                description: desc!("シールド保護中にDMG+12-24%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.12,
                 nightsoul_value: None,
@@ -1000,11 +1030,11 @@ pub const TIDAL_SHADOW: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Tidal Shadow",
         effect: PassiveEffect {
-            description: "HP回復時にATK+24-48%（8秒）",
+            description: desc!("HP回復時にATK+24-48%（8秒）"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "tidal_shadow_atk",
-                description: "HP回復時にATK+24-48%",
+                description: desc!("HP回復時にATK+24-48%"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.24,
                 nightsoul_value: None,
@@ -1027,12 +1057,16 @@ pub const ULTIMATE_OVERLORDS_MEGA_MAGIC_SWORD: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "魔王の究極の一撃",
         effect: PassiveEffect {
-            description: "チーム内に異なる元素タイプ1つにつきATK+4-8%/DMG+3.5-7%（最大4タイプ）",
+            description: desc!(
+                "チーム内に異なる元素タイプ1つにつきATK+4-8%/DMG+3.5-7%（最大4タイプ）"
+            ),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "ultimate_sword_atk",
-                    description: "チーム内の異なる元素タイプ1つにつきATK+4-8%（最大4タイプ）",
+                    description: desc!(
+                        "チーム内の異なる元素タイプ1つにつきATK+4-8%（最大4タイプ）"
+                    ),
                     stat: BuffableStat::AtkPercent,
                     value: 0.04,
                     nightsoul_value: None,
@@ -1045,7 +1079,9 @@ pub const ULTIMATE_OVERLORDS_MEGA_MAGIC_SWORD: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "ultimate_sword_dmg",
-                    description: "チーム内の異なる元素タイプ1つにつきDMG+3.5-7%（最大4タイプ）",
+                    description: desc!(
+                        "チーム内の異なる元素タイプ1つにつきDMG+3.5-7%（最大4タイプ）"
+                    ),
                     stat: BuffableStat::DmgBonus,
                     value: 0.035,
                     nightsoul_value: None,
@@ -1071,12 +1107,12 @@ pub const WHITEBLIND: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "精錬の極み",
         effect: PassiveEffect {
-            description: "通常/重撃命中でATK+6-12%/DEF+6-12%（1スタック分）、最大4スタック",
+            description: desc!("通常/重撃命中でATK+6-12%/DEF+6-12%（1スタック分）、最大4スタック"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "whiteblind_atk",
-                    description: "通常/重撃命中でATK+6-12%（1スタック）、最大4スタック",
+                    description: desc!("通常/重撃命中でATK+6-12%（1スタック）、最大4スタック"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.06,
                     nightsoul_value: None,
@@ -1087,7 +1123,7 @@ pub const WHITEBLIND: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "whiteblind_def",
-                    description: "通常/重撃命中でDEF+6-12%（1スタック）、最大4スタック",
+                    description: desc!("通常/重撃命中でDEF+6-12%（1スタック）、最大4スタック"),
                     stat: BuffableStat::DefPercent,
                     value: 0.06,
                     nightsoul_value: None,
@@ -1115,11 +1151,11 @@ pub const BLOODTAINTED_GREATSWORD: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "炎と雷の渇き",
         effect: PassiveEffect {
-            description: "炎/雷元素影響下の敵へのDMG+12-24%",
+            description: desc!("炎/雷元素影響下の敵へのDMG+12-24%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "bloodtainted_dmg",
-                description: "炎/雷元素影響下の敵に対してDMG+12-24%",
+                description: desc!("炎/雷元素影響下の敵に対してDMG+12-24%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.12,
                 nightsoul_value: None,
@@ -1142,7 +1178,7 @@ pub const DEBATE_CLUB: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "議論",
         effect: PassiveEffect {
-            description: "Conditional: スキル使用後に通常/重撃で追加ATKダメージ、15秒に1回",
+            description: desc!("Conditional: スキル使用後に通常/重撃で追加ATKダメージ、15秒に1回"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -1159,11 +1195,11 @@ pub const FERROUS_SHADOW: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "鉄の影",
         effect: PassiveEffect {
-            description: "HP70%以下の時に重撃の中断耐性上昇、重撃DMG+30-50%",
+            description: desc!("HP70%以下の時に重撃の中断耐性上昇、重撃DMG+30-50%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "ferrous_shadow_charged_dmg",
-                description: "HP70%以下の時に重撃DMG+30-50%",
+                description: desc!("HP70%以下の時に重撃DMG+30-50%"),
                 stat: BuffableStat::ChargedAtkDmgBonus,
                 value: 0.30,
                 nightsoul_value: None,
@@ -1188,11 +1224,11 @@ pub const SKYRIDER_GREATSWORD: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "勇気",
         effect: PassiveEffect {
-            description: "通常/重撃命中でATK+6-10%（1スタック）、6秒、最大4スタック",
+            description: desc!("通常/重撃命中でATK+6-10%（1スタック）、6秒、最大4スタック"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "skyrider_greatsword_atk_stacks",
-                description: "通常/重撃命中毎にATK+6-10%（1スタック）、最大4スタック",
+                description: desc!("通常/重撃命中毎にATK+6-10%（1スタック）、最大4スタック"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.06,
                 nightsoul_value: None,
@@ -1215,7 +1251,7 @@ pub const WHITE_IRON_GREATSWORD: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "白鉄の意志",
         effect: PassiveEffect {
-            description: "Conditional: 敵を倒すとHP回復",
+            description: desc!("Conditional: 敵を倒すとHP回復"),
             buffs: &[],
             conditional_buffs: &[],
         },

--- a/crates/data/src/weapons/polearm.rs
+++ b/crates/data/src/weapons/polearm.rs
@@ -18,12 +18,14 @@ pub const BLOODSOAKED_RUINS: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Mournful Tribute",
         effect: PassiveEffect {
-            description: "爆発使用後3.5秒間、月感電DMG+36-84%。月感電反応トリガー後6秒間CRIT DMG+28-56%。エネルギー12-16回復（14秒に1回）",
+            description: desc!(
+                "爆発使用後3.5秒間、月感電DMG+36-84%。月感電反応トリガー後6秒間CRIT DMG+28-56%。エネルギー12-16回復（14秒に1回）"
+            ),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "bloodsoaked_ruins_lunar_dmg",
-                    description: "爆発使用後3.5秒間、月感電DMG+36-84%（DmgBonusで近似）",
+                    description: desc!("爆発使用後3.5秒間、月感電DMG+36-84%（DmgBonusで近似）"),
                     stat: BuffableStat::DmgBonus,
                     value: 0.36,
                     nightsoul_value: None,
@@ -34,7 +36,7 @@ pub const BLOODSOAKED_RUINS: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "bloodsoaked_ruins_crit_dmg",
-                    description: "月感電反応トリガー後6秒間CRIT DMG+28-56%",
+                    description: desc!("月感電反応トリガー後6秒間CRIT DMG+28-56%"),
                     stat: BuffableStat::CritDmg,
                     value: 0.28,
                     nightsoul_value: None,
@@ -58,7 +60,9 @@ pub const CALAMITY_QUELLER: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "息災",
         effect: PassiveEffect {
-            description: "Ele DMG+12-24%。元素スキル使用後ATK+3.2-6.4%/スタック、未出場時は2倍（最大6スタック）",
+            description: desc!(
+                "Ele DMG+12-24%。元素スキル使用後ATK+3.2-6.4%/スタック、未出場時は2倍（最大6スタック）"
+            ),
             buffs: &[StatBuff {
                 stat: BuffableStat::DmgBonus,
                 value: 0.12,
@@ -67,7 +71,9 @@ pub const CALAMITY_QUELLER: WeaponData = WeaponData {
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "calamity_queller_atk_onfield",
-                    description: "元素スキル使用後ATK+3.2-6.4%（1スタック）、最大6スタック（フィールド上）",
+                    description: desc!(
+                        "元素スキル使用後ATK+3.2-6.4%（1スタック）、最大6スタック（フィールド上）"
+                    ),
                     stat: BuffableStat::AtkPercent,
                     value: 0.032,
                     nightsoul_value: None,
@@ -78,7 +84,7 @@ pub const CALAMITY_QUELLER: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "calamity_queller_atk_offfield",
-                    description: "未出場時はATKスタック効果2倍（追加ATK+3.2-6.4%/スタック）",
+                    description: desc!("未出場時はATKスタック効果2倍（追加ATK+3.2-6.4%/スタック）"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.032,
                     nightsoul_value: None,
@@ -102,12 +108,14 @@ pub const CRIMSON_MOONS_SEMBLANCE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Ashen Sun's Shadow",
         effect: PassiveEffect {
-            description: "Bond of Life時DMG+12-28%。BoLがHP上限30%以上の時さらにDMG+24-56%。重撃命中でHP上限の25%分BoL付与（14秒に1回）",
+            description: desc!(
+                "Bond of Life時DMG+12-28%。BoLがHP上限30%以上の時さらにDMG+24-56%。重撃命中でHP上限の25%分BoL付与（14秒に1回）"
+            ),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "crimson_moons_semblance_bol_dmg",
-                    description: "Bond of Life保有時にDMG+12-28%",
+                    description: desc!("Bond of Life保有時にDMG+12-28%"),
                     stat: BuffableStat::DmgBonus,
                     value: 0.12,
                     nightsoul_value: None,
@@ -118,7 +126,7 @@ pub const CRIMSON_MOONS_SEMBLANCE: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "crimson_moons_semblance_bol_high_dmg",
-                    description: "BoLがHP上限の30%以上の時さらにDMG+24-56%",
+                    description: desc!("BoLがHP上限の30%以上の時さらにDMG+24-56%"),
                     stat: BuffableStat::DmgBonus,
                     value: 0.24,
                     nightsoul_value: None,
@@ -142,12 +150,12 @@ pub const ENGULFING_LIGHTNING: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "漁獲の雷",
         effect: PassiveEffect {
-            description: "Conditional: ERに基づきATKアップ。元素爆発後にER+30%",
+            description: desc!("Conditional: ERに基づきATKアップ。元素爆発後にER+30%"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "engulfing_er_atk",
-                    description: "ER超過分の28-56%をATK%に変換 (cap: 80-120%)",
+                    description: desc!("ER超過分の28-56%をATK%に変換 (cap: 80-120%)"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.28,
                     nightsoul_value: None,
@@ -162,7 +170,7 @@ pub const ENGULFING_LIGHTNING: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "engulfing_burst_er",
-                    description: "元素爆発後12秒間ER+30-50%",
+                    description: desc!("元素爆発後12秒間ER+30-50%"),
                     stat: BuffableStat::EnergyRecharge,
                     value: 0.30,
                     nightsoul_value: None,
@@ -186,12 +194,14 @@ pub const FRACTURED_HALO: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Purifying Crown",
         effect: PassiveEffect {
-            description: "スキル/爆発使用後20秒間ATK+24-48%。シールド生成時に20秒間、チーム全員の月感電DMG+40-80%",
+            description: desc!(
+                "スキル/爆発使用後20秒間ATK+24-48%。シールド生成時に20秒間、チーム全員の月感電DMG+40-80%"
+            ),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "fractured_halo_atk",
-                    description: "スキル/爆発使用後20秒間ATK+24-48%",
+                    description: desc!("スキル/爆発使用後20秒間ATK+24-48%"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.24,
                     nightsoul_value: None,
@@ -202,7 +212,9 @@ pub const FRACTURED_HALO: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "fractured_halo_team_lunar_dmg",
-                    description: "シールド生成時チーム全員の月感電DMG+40-80%（DmgBonusで近似）",
+                    description: desc!(
+                        "シールド生成時チーム全員の月感電DMG+40-80%（DmgBonusで近似）"
+                    ),
                     stat: BuffableStat::DmgBonus,
                     value: 0.40,
                     nightsoul_value: None,
@@ -226,7 +238,9 @@ pub const LUMIDOUCE_ELEGY: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Bright Dawn Overture",
         effect: PassiveEffect {
-            description: "ATK+15-31%。燃焼反応トリガー後/燃焼状態の敵に草元素DMG後8秒間ダメージ+18-38%（最大2スタック）。2スタック時/更新時エネルギー12-16回復（12秒に1回）",
+            description: desc!(
+                "ATK+15-31%。燃焼反応トリガー後/燃焼状態の敵に草元素DMG後8秒間ダメージ+18-38%（最大2スタック）。2スタック時/更新時エネルギー12-16回復（12秒に1回）"
+            ),
             buffs: &[StatBuff {
                 stat: BuffableStat::AtkPercent,
                 value: 0.15,
@@ -234,7 +248,9 @@ pub const LUMIDOUCE_ELEGY: WeaponData = WeaponData {
             }],
             conditional_buffs: &[ConditionalBuff {
                 name: "lumidouce_elegy_burning_dmg",
-                description: "燃焼反応トリガー/燃焼状態の敵に草元素DMG後8秒間DMG+18-38%（1スタック）、最大2スタック",
+                description: desc!(
+                    "燃焼反応トリガー/燃焼状態の敵に草元素DMG後8秒間DMG+18-38%（1スタック）、最大2スタック"
+                ),
                 stat: BuffableStat::DmgBonus,
                 value: 0.18,
                 nightsoul_value: None,
@@ -257,12 +273,12 @@ pub const PRIMORDIAL_JADE_WINGED_SPEAR: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "昭理の鳶",
         effect: PassiveEffect {
-            description: "命中時にATK+3.2-6%、6スタックまで。フルスタックでDMG+12-24%",
+            description: desc!("命中時にATK+3.2-6%、6スタックまで。フルスタックでDMG+12-24%"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "pjws_atk_stacks",
-                    description: "命中時にATK+3.2-6%（1スタック）、最大6スタック",
+                    description: desc!("命中時にATK+3.2-6%（1スタック）、最大6スタック"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.032,
                     nightsoul_value: None,
@@ -273,7 +289,7 @@ pub const PRIMORDIAL_JADE_WINGED_SPEAR: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "pjws_full_stack_dmg",
-                    description: "フルスタック時にDMG+12-24%",
+                    description: desc!("フルスタック時にDMG+12-24%"),
                     stat: BuffableStat::DmgBonus,
                     value: 0.12,
                     nightsoul_value: None,
@@ -297,7 +313,7 @@ pub const SKYWARD_SPINE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "天空の脊",
         effect: PassiveEffect {
-            description: "CRIT Rate+8-16%。攻撃速度+12%。通常/重撃命中時に追加ダメージ",
+            description: desc!("CRIT Rate+8-16%。攻撃速度+12%。通常/重撃命中時に追加ダメージ"),
             buffs: &[StatBuff {
                 stat: BuffableStat::CritRate,
                 value: 0.08,
@@ -318,7 +334,9 @@ pub const STAFF_OF_HOMA: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "護摩の杖",
         effect: PassiveEffect {
-            description: "HP+20-40%。HP上限の0.8-1.6%分ATKアップ。HP50%以下でさらに1.0-1.8%分アップ",
+            description: desc!(
+                "HP+20-40%。HP上限の0.8-1.6%分ATKアップ。HP50%以下でさらに1.0-1.8%分アップ"
+            ),
             buffs: &[StatBuff {
                 stat: BuffableStat::HpPercent,
                 value: 0.20,
@@ -327,7 +345,7 @@ pub const STAFF_OF_HOMA: WeaponData = WeaponData {
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "homa_hp_atk",
-                    description: "HP上限の0.8%分ATKアップ（常時）",
+                    description: desc!("HP上限の0.8%分ATKアップ（常時）"),
                     stat: BuffableStat::AtkFlat,
                     value: 0.008,
                     nightsoul_value: None,
@@ -342,7 +360,7 @@ pub const STAFF_OF_HOMA: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "homa_low_hp_atk",
-                    description: "HP50%以下の時、さらにHP上限の1.0%分ATKアップ",
+                    description: desc!("HP50%以下の時、さらにHP上限の1.0%分ATKアップ"),
                     stat: BuffableStat::AtkFlat,
                     value: 0.010,
                     nightsoul_value: None,
@@ -373,12 +391,12 @@ pub const STAFF_OF_THE_SCARLET_SANDS: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "赤砂の杖",
         effect: PassiveEffect {
-            description: "Conditional: EMに基づきATKアップ。スキル命中でさらにATKアップ",
+            description: desc!("Conditional: EMに基づきATKアップ。スキル命中でさらにATKアップ"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "scarlet_sands_em_atk",
-                    description: "EM×52-104%分をATKフラットに加算",
+                    description: desc!("EM×52-104%分をATKフラットに加算"),
                     stat: BuffableStat::AtkFlat,
                     value: 0.52,
                     nightsoul_value: None,
@@ -396,7 +414,7 @@ pub const STAFF_OF_THE_SCARLET_SANDS: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "scarlet_sands_skill_stacks",
-                    description: "スキル命中後10秒間、EM×28-56%分ATKアップ。最大2スタック",
+                    description: desc!("スキル命中後10秒間、EM×28-56%分ATKアップ。最大2スタック"),
                     stat: BuffableStat::AtkFlat,
                     value: 0.28,
                     nightsoul_value: None,
@@ -427,7 +445,9 @@ pub const SYMPHONIST_OF_SCENTS: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Seasoned Symphony",
         effect: PassiveEffect {
-            description: "ATK+12-24%。未出場時さらにATK+12-24%。ヒール発動後に装備者とヒール対象のATK+32-64%（3秒間）",
+            description: desc!(
+                "ATK+12-24%。未出場時さらにATK+12-24%。ヒール発動後に装備者とヒール対象のATK+32-64%（3秒間）"
+            ),
             buffs: &[StatBuff {
                 stat: BuffableStat::AtkPercent,
                 value: 0.12,
@@ -436,7 +456,7 @@ pub const SYMPHONIST_OF_SCENTS: WeaponData = WeaponData {
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "symphonist_of_scents_offfield_atk",
-                    description: "未出場時さらにATK+12-24%",
+                    description: desc!("未出場時さらにATK+12-24%"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.12,
                     nightsoul_value: None,
@@ -447,7 +467,7 @@ pub const SYMPHONIST_OF_SCENTS: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "symphonist_of_scents_sweet_echoes",
-                    description: "ヒール発動後に装備者とヒール対象のATK+32-64%（3秒間）",
+                    description: desc!("ヒール発動後に装備者とヒール対象のATK+32-64%（3秒間）"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.32,
                     nightsoul_value: None,
@@ -471,12 +491,12 @@ pub const VORTEX_VANQUISHER: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "金璋の槍",
         effect: PassiveEffect {
-            description: "攻撃命中でATK+4-8%スタック（最大5）、シールド時は2倍",
+            description: desc!("攻撃命中でATK+4-8%スタック（最大5）、シールド時は2倍"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "vortex_vanquisher_atk_stacks",
-                    description: "攻撃命中でATK+4-8%（1スタック）、最大5スタック",
+                    description: desc!("攻撃命中でATK+4-8%（1スタック）、最大5スタック"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.04,
                     nightsoul_value: None,
@@ -487,7 +507,7 @@ pub const VORTEX_VANQUISHER: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "vortex_vanquisher_shield_atk_stacks",
-                    description: "シールド時にATKスタック効果2倍分（追加ATK+4-8%/スタック）",
+                    description: desc!("シールド時にATKスタック効果2倍分（追加ATK+4-8%/スタック）"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.04,
                     nightsoul_value: None,
@@ -515,11 +535,11 @@ pub const BALLAD_OF_THE_FJORDS: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Ballad of the Fjords",
         effect: PassiveEffect {
-            description: "チーム内に3種以上の異なる元素があるときEM+120-240",
+            description: desc!("チーム内に3種以上の異なる元素があるときEM+120-240"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "ballad_of_the_fjords_em",
-                description: "チーム内に3種以上の異なる元素があるときEM+120-240",
+                description: desc!("チーム内に3種以上の異なる元素があるときEM+120-240"),
                 stat: BuffableStat::ElementalMastery,
                 value: 120.0,
                 nightsoul_value: None,
@@ -544,7 +564,7 @@ pub const CRESCENT_PIKE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "白月の槍",
         effect: PassiveEffect {
-            description: "Conditional: 元素粒子取得後に通常/重撃で追加ATKダメージ",
+            description: desc!("Conditional: 元素粒子取得後に通常/重撃で追加ATKダメージ"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -561,12 +581,12 @@ pub const DEATHMATCH: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "闘志",
         effect: PassiveEffect {
-            description: "敵2体以上: ATK/DEF+16-32%。敵1体以下: ATK+24-48%",
+            description: desc!("敵2体以上: ATK/DEF+16-32%。敵1体以下: ATK+24-48%"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "deathmatch_atk_multi",
-                    description: "敵2体以上でATK+16-32%",
+                    description: desc!("敵2体以上でATK+16-32%"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.16,
                     nightsoul_value: None,
@@ -577,7 +597,7 @@ pub const DEATHMATCH: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "deathmatch_def_multi",
-                    description: "敵2体以上でDEF+16-32%",
+                    description: desc!("敵2体以上でDEF+16-32%"),
                     stat: BuffableStat::DefPercent,
                     value: 0.16,
                     nightsoul_value: None,
@@ -588,7 +608,7 @@ pub const DEATHMATCH: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "deathmatch_atk_1enemy",
-                    description: "敵1体以下でATK+24-48%",
+                    description: desc!("敵1体以下でATK+24-48%"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.24,
                     nightsoul_value: None,
@@ -612,7 +632,9 @@ pub const DIALOGUES_OF_THE_DESERT_SAGES: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Principle of Equilibrium",
         effect: PassiveEffect {
-            description: "SKIP: ヒール発動時にエネルギー8-16回復（10秒に1回、未出場時も有効）",
+            description: desc!(
+                "SKIP: ヒール発動時にエネルギー8-16回復（10秒に1回、未出場時も有効）"
+            ),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -629,11 +651,11 @@ pub const DRAGONS_BANE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "炎と水の滅竜",
         effect: PassiveEffect {
-            description: "水/炎元素影響下の敵へのDMG+20-36%",
+            description: desc!("水/炎元素影響下の敵へのDMG+20-36%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "dragons_bane_dmg",
-                description: "水/炎元素の影響下の敵へのDMG+20-36%",
+                description: desc!("水/炎元素の影響下の敵へのDMG+20-36%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.20,
                 nightsoul_value: None,
@@ -658,7 +680,9 @@ pub const DRAGONSPINE_SPEAR: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "霜葬の槍",
         effect: PassiveEffect {
-            description: "Conditional: 通常/重撃命中時に氷柱落下、氷元素影響下の敵には追加ダメージ",
+            description: desc!(
+                "Conditional: 通常/重撃命中時に氷柱落下、氷元素影響下の敵には追加ダメージ"
+            ),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -675,7 +699,7 @@ pub const FAVONIUS_LANCE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "西風の息吹",
         effect: PassiveEffect {
-            description: "Conditional: 会心命中時に元素粒子を生成、12-6秒に1回",
+            description: desc!("Conditional: 会心命中時に元素粒子を生成、12-6秒に1回"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -692,11 +716,11 @@ pub const FOOTPRINT_OF_THE_RAINBOW: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Pact of Flowing Springs",
         effect: PassiveEffect {
-            description: "元素スキル使用後15秒間DEF+16-32%",
+            description: desc!("元素スキル使用後15秒間DEF+16-32%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "footprint_of_the_rainbow_def",
-                description: "元素スキル使用後15秒間DEF+16-32%",
+                description: desc!("元素スキル使用後15秒間DEF+16-32%"),
                 stat: BuffableStat::DefPercent,
                 value: 0.16,
                 nightsoul_value: None,
@@ -719,7 +743,7 @@ pub const KITAIN_CROSS_SPEAR: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "名刀・北谷の十字槍",
         effect: PassiveEffect {
-            description: "Skill DMG+6-12%。スキル命中で元素エネルギー消費後に回復",
+            description: desc!("Skill DMG+6-12%。スキル命中で元素エネルギー消費後に回復"),
             buffs: &[StatBuff {
                 stat: BuffableStat::SkillDmgBonus,
                 value: 0.06,
@@ -740,12 +764,12 @@ pub const LITHIC_SPEAR: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "千岩の槍",
         effect: PassiveEffect {
-            description: "Conditional: チーム内の璃月キャラ人数に応じてATK/CRIT Rateアップ",
+            description: desc!("Conditional: チーム内の璃月キャラ人数に応じてATK/CRIT Rateアップ"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "lithic_spear_atk",
-                    description: "璃月キャラ1人につきATK+7-11%",
+                    description: desc!("璃月キャラ1人につきATK+7-11%"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.07,
                     nightsoul_value: None,
@@ -758,7 +782,7 @@ pub const LITHIC_SPEAR: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "lithic_spear_crit",
-                    description: "璃月キャラ1人につきCR+3-7%",
+                    description: desc!("璃月キャラ1人につきCR+3-7%"),
                     stat: BuffableStat::CritRate,
                     value: 0.03,
                     nightsoul_value: None,
@@ -784,12 +808,12 @@ pub const MISSIVE_WINDSPEAR: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Missive Windspear",
         effect: PassiveEffect {
-            description: "元素反応トリガー後10秒間ATK+12-24%、EM+48-96",
+            description: desc!("元素反応トリガー後10秒間ATK+12-24%、EM+48-96"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "missive_windspear_atk",
-                    description: "元素反応トリガー後10秒間ATK+12-24%",
+                    description: desc!("元素反応トリガー後10秒間ATK+12-24%"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.12,
                     nightsoul_value: None,
@@ -800,7 +824,7 @@ pub const MISSIVE_WINDSPEAR: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "missive_windspear_em",
-                    description: "元素反応トリガー後10秒間EM+48-96",
+                    description: desc!("元素反応トリガー後10秒間EM+48-96"),
                     stat: BuffableStat::ElementalMastery,
                     value: 48.0,
                     nightsoul_value: None,
@@ -824,11 +848,11 @@ pub const MOONPIERCER: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "月穿ち",
         effect: PassiveEffect {
-            description: "草元素反応で種を生成、種を取得するとATK+16-32%",
+            description: desc!("草元素反応で種を生成、種を取得するとATK+16-32%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "moonpiercer_atk",
-                description: "草元素反応で生成した種を取得するとATK+16-32%",
+                description: desc!("草元素反応で生成した種を取得するとATK+16-32%"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.16,
                 nightsoul_value: None,
@@ -851,7 +875,9 @@ pub const MOUNTAIN_BRACING_BOLT: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Hope Beyond the Peaks",
         effect: PassiveEffect {
-            description: "Skill DMG+12-24%（常時）。他のパーティメンバーがスキル使用後8秒間、さらにSkill DMG+12-24%。登山スタミナ消費-15%",
+            description: desc!(
+                "Skill DMG+12-24%（常時）。他のパーティメンバーがスキル使用後8秒間、さらにSkill DMG+12-24%。登山スタミナ消費-15%"
+            ),
             buffs: &[StatBuff {
                 stat: BuffableStat::SkillDmgBonus,
                 value: 0.12,
@@ -859,7 +885,9 @@ pub const MOUNTAIN_BRACING_BOLT: WeaponData = WeaponData {
             }],
             conditional_buffs: &[ConditionalBuff {
                 name: "mountain_bracing_bolt_skill_dmg_team",
-                description: "他のパーティメンバーがスキル使用後8秒間、さらにSkill DMG+12-24%",
+                description: desc!(
+                    "他のパーティメンバーがスキル使用後8秒間、さらにSkill DMG+12-24%"
+                ),
                 stat: BuffableStat::SkillDmgBonus,
                 value: 0.12,
                 nightsoul_value: None,
@@ -882,12 +910,14 @@ pub const PROSPECTORS_DRILL: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Masons' Ditty",
         effect: PassiveEffect {
-            description: "ヒール時にUnityの印蓄積（最大3）。スキル/爆発使用で全スタック消費→1スタックごとにATK+3-7%+全元素DMG+7-13%（Struggle効果、15秒に1回）",
+            description: desc!(
+                "ヒール時にUnityの印蓄積（最大3）。スキル/爆発使用で全スタック消費→1スタックごとにATK+3-7%+全元素DMG+7-13%（Struggle効果、15秒に1回）"
+            ),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "prospectors_drill_atk",
-                    description: "Unityの印消費時（1スタックごと）ATK+3-7%、最大3スタック",
+                    description: desc!("Unityの印消費時（1スタックごと）ATK+3-7%、最大3スタック"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.03,
                     nightsoul_value: None,
@@ -898,7 +928,9 @@ pub const PROSPECTORS_DRILL: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "prospectors_drill_ele_dmg",
-                    description: "Unityの印消費時（1スタックごと）全元素DMG+7-13%、最大3スタック",
+                    description: desc!(
+                        "Unityの印消費時（1スタックごと）全元素DMG+7-13%、最大3スタック"
+                    ),
                     stat: BuffableStat::DmgBonus,
                     value: 0.07,
                     nightsoul_value: None,
@@ -922,7 +954,9 @@ pub const PROSPECTORS_SHOVEL: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Swift and Sure",
         effect: PassiveEffect {
-            description: "SKIP(反応特化): 感電DMG+48-96%、月感電DMG+12-24%（常時）。Nod-Kraiキャラ2人以上時さらに月感電DMG+12-24%。反応特化BuffableStatなし→実装対象外",
+            description: desc!(
+                "SKIP(反応特化): 感電DMG+48-96%、月感電DMG+12-24%（常時）。Nod-Kraiキャラ2人以上時さらに月感電DMG+12-24%。反応特化BuffableStatなし→実装対象外"
+            ),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -939,12 +973,14 @@ pub const PROTOTYPE_STARGLITTER: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "魔力の導き",
         effect: PassiveEffect {
-            description: "元素スキル使用後に通常/重撃DMG+8-16%（最大2スタック）",
+            description: desc!("元素スキル使用後に通常/重撃DMG+8-16%（最大2スタック）"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "prototype_starglitter_na_dmg",
-                    description: "元素スキル使用後に通常攻撃DMG+8-16%（1スタック）、最大2スタック",
+                    description: desc!(
+                        "元素スキル使用後に通常攻撃DMG+8-16%（1スタック）、最大2スタック"
+                    ),
                     stat: BuffableStat::NormalAtkDmgBonus,
                     value: 0.08,
                     nightsoul_value: None,
@@ -955,7 +991,9 @@ pub const PROTOTYPE_STARGLITTER: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "prototype_starglitter_ca_dmg",
-                    description: "元素スキル使用後に重撃DMG+8-16%（1スタック）、最大2スタック",
+                    description: desc!(
+                        "元素スキル使用後に重撃DMG+8-16%（1スタック）、最大2スタック"
+                    ),
                     stat: BuffableStat::ChargedAtkDmgBonus,
                     value: 0.08,
                     nightsoul_value: None,
@@ -979,7 +1017,7 @@ pub const RIGHTFUL_REWARD: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Rightful Reward",
         effect: PassiveEffect {
-            description: "Conditional: 元素スキル命中でHP回復",
+            description: desc!("Conditional: 元素スキル命中でHP回復"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -996,11 +1034,15 @@ pub const ROYAL_SPEAR: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "集中",
         effect: PassiveEffect {
-            description: "ダメージを与えるとCRIT Rate+8-16%（最大5スタック）、会心発生でリセット",
+            description: desc!(
+                "ダメージを与えるとCRIT Rate+8-16%（最大5スタック）、会心発生でリセット"
+            ),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "royal_spear_cr",
-                description: "ダメージを与えるとCRIT Rate+8-16%（1スタック）、最大5スタック（会心でリセット）",
+                description: desc!(
+                    "ダメージを与えるとCRIT Rate+8-16%（1スタック）、最大5スタック（会心でリセット）"
+                ),
                 stat: BuffableStat::CritRate,
                 value: 0.08,
                 nightsoul_value: None,
@@ -1023,12 +1065,14 @@ pub const SACRIFICERS_STAFF: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Untainted Desire",
         effect: PassiveEffect {
-            description: "スキル命中後6秒間、ATK+8-16%・ER+6-12%（最大3スタック、未出場時も有効）",
+            description: desc!(
+                "スキル命中後6秒間、ATK+8-16%・ER+6-12%（最大3スタック、未出場時も有効）"
+            ),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "sacrificers_staff_atk",
-                    description: "スキル命中後6秒間ATK+8-16%（1スタック）、最大3スタック",
+                    description: desc!("スキル命中後6秒間ATK+8-16%（1スタック）、最大3スタック"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.08,
                     nightsoul_value: None,
@@ -1039,7 +1083,7 @@ pub const SACRIFICERS_STAFF: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "sacrificers_staff_er",
-                    description: "スキル命中後6秒間ER+6-12%（1スタック）、最大3スタック",
+                    description: desc!("スキル命中後6秒間ER+6-12%（1スタック）、最大3スタック"),
                     stat: BuffableStat::EnergyRecharge,
                     value: 0.06,
                     nightsoul_value: None,
@@ -1063,11 +1107,13 @@ pub const TAMAYURATEI_NO_OHANASHI: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Busybody's Running Light",
         effect: PassiveEffect {
-            description: "元素スキル使用後10秒間ATK+20-40%。移動速度+10%（ダメージ計算無関係）",
+            description: desc!(
+                "元素スキル使用後10秒間ATK+20-40%。移動速度+10%（ダメージ計算無関係）"
+            ),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "tamayuratei_no_ohanashi_atk",
-                description: "元素スキル使用後10秒間ATK+20-40%",
+                description: desc!("元素スキル使用後10秒間ATK+20-40%"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.20,
                 nightsoul_value: None,
@@ -1090,7 +1136,7 @@ pub const THE_CATCH: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "漁獲",
         effect: PassiveEffect {
-            description: "Burst DMG+16-32%、Burst CRIT Rate+6-12%",
+            description: desc!("Burst DMG+16-32%、Burst CRIT Rate+6-12%"),
             buffs: &[
                 StatBuff {
                     stat: BuffableStat::BurstDmgBonus,
@@ -1118,11 +1164,15 @@ pub const WAVEBREAKERS_FIN: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "波乗りの鰭",
         effect: PassiveEffect {
-            description: "チーム全員の元素エネルギー上限合計に基づきBurst DMG+最大40-80%（総EP240超時）",
+            description: desc!(
+                "チーム全員の元素エネルギー上限合計に基づきBurst DMG+最大40-80%（総EP240超時）"
+            ),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "wavebreakers_fin_burst_dmg",
-                description: "チーム全員の元素エネルギー上限合計に基づきBurst DMG+最大40-80%（240EP基準）",
+                description: desc!(
+                    "チーム全員の元素エネルギー上限合計に基づきBurst DMG+最大40-80%（240EP基準）"
+                ),
                 stat: BuffableStat::BurstDmgBonus,
                 value: 0.40,
                 nightsoul_value: None,
@@ -1149,11 +1199,11 @@ pub const BLACK_TASSEL: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "黒纓の槍",
         effect: PassiveEffect {
-            description: "スライムへのDMG+40-80%",
+            description: desc!("スライムへのDMG+40-80%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "black_tassel_slime_dmg",
-                description: "スライムへのDMG+40-80%",
+                description: desc!("スライムへのDMG+40-80%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.40,
                 nightsoul_value: None,
@@ -1176,7 +1226,7 @@ pub const HALBERD: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "鉤戟",
         effect: PassiveEffect {
-            description: "Conditional: 通常攻撃命中時に追加ATKダメージ、10秒に1回",
+            description: desc!("Conditional: 通常攻撃命中時に追加ATKダメージ、10秒に1回"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -1193,7 +1243,7 @@ pub const WHITE_TASSEL: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "白纓の槍",
         effect: PassiveEffect {
-            description: "NA DMG+24-48%",
+            description: desc!("NA DMG+24-48%"),
             buffs: &[StatBuff {
                 stat: BuffableStat::NormalAtkDmgBonus,
                 value: 0.24,

--- a/crates/data/src/weapons/sword.rs
+++ b/crates/data/src/weapons/sword.rs
@@ -18,7 +18,7 @@ pub const ABSOLUTION: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Absolution",
         effect: PassiveEffect {
-            description: "CRIT DMG+20-40%。罪禍を蓄積して追加CRIT DMGを獲得",
+            description: desc!("CRIT DMG+20-40%。罪禍を蓄積して追加CRIT DMGを獲得"),
             buffs: &[StatBuff {
                 stat: BuffableStat::CritDmg,
                 value: 0.20,
@@ -26,7 +26,7 @@ pub const ABSOLUTION: WeaponData = WeaponData {
             }],
             conditional_buffs: &[ConditionalBuff {
                 name: "absolution_crit_dmg",
-                description: "罪禍スタックごとにCRIT DMG+16-32%",
+                description: desc!("罪禍スタックごとにCRIT DMG+16-32%"),
                 stat: BuffableStat::CritDmg,
                 value: 0.16,
                 nightsoul_value: None,
@@ -51,7 +51,9 @@ pub const AQUILA_FAVONIA: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "西風の鷹の抗い",
         effect: PassiveEffect {
-            description: "ATK+20-40%。ダメージを受けると再生効果と追加ATKダメージ、15秒に1回",
+            description: desc!(
+                "ATK+20-40%。ダメージを受けると再生効果と追加ATKダメージ、15秒に1回"
+            ),
             buffs: &[StatBuff {
                 stat: BuffableStat::AtkPercent,
                 value: 0.20,
@@ -72,12 +74,14 @@ pub const ATHAME_ARTIS: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Athame Artis",
         effect: PassiveEffect {
-            description: "元素スキル使用後にスキルCR+10-20%/スキルDMG+8-16%（CritRate近似値）",
+            description: desc!(
+                "元素スキル使用後にスキルCR+10-20%/スキルDMG+8-16%（CritRate近似値）"
+            ),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "athame_artis_skill_cr",
-                    description: "元素スキル使用後にCR+10-20%（スキルのみ。CritRate近似値）",
+                    description: desc!("元素スキル使用後にCR+10-20%（スキルのみ。CritRate近似値）"),
                     stat: BuffableStat::CritRate,
                     value: 0.10,
                     nightsoul_value: None,
@@ -88,7 +92,7 @@ pub const ATHAME_ARTIS: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "athame_artis_skill_dmg",
-                    description: "元素スキル使用後にスキルDMG+8-16%",
+                    description: desc!("元素スキル使用後にスキルDMG+8-16%"),
                     stat: BuffableStat::SkillDmgBonus,
                     value: 0.08,
                     nightsoul_value: None,
@@ -112,11 +116,11 @@ pub const AZURELIGHT: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Azurelight",
         effect: PassiveEffect {
-            description: "HP上限×0.16-0.32%分をNA DMGボーナスに加算（条件付き、上限40-80%）",
+            description: desc!("HP上限×0.16-0.32%分をNA DMGボーナスに加算（条件付き、上限40-80%）"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "azurelight_hp_na_dmg",
-                description: "HP上限×0.16-0.32%分をNA DMGに加算",
+                description: desc!("HP上限×0.16-0.32%分をNA DMGに加算"),
                 stat: BuffableStat::NormalAtkDmgBonus,
                 value: 0.0016,
                 nightsoul_value: None,
@@ -146,7 +150,9 @@ pub const FREEDOM_SWORN: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "革命の翼",
         effect: PassiveEffect {
-            description: "DMG+10-20%。元素反応時に印を蓄積、2つでチーム全員にATK+20%/NA・CA・PlungeDMG+16%",
+            description: desc!(
+                "DMG+10-20%。元素反応時に印を蓄積、2つでチーム全員にATK+20%/NA・CA・PlungeDMG+16%"
+            ),
             buffs: &[StatBuff {
                 stat: BuffableStat::DmgBonus,
                 value: 0.10,
@@ -155,7 +161,7 @@ pub const FREEDOM_SWORN: WeaponData = WeaponData {
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "freedom_sworn_team_atk",
-                    description: "印2個蓄積後にチーム全員にATK+20-40%",
+                    description: desc!("印2個蓄積後にチーム全員にATK+20-40%"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.20,
                     nightsoul_value: None,
@@ -166,7 +172,7 @@ pub const FREEDOM_SWORN: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "freedom_sworn_team_na_dmg",
-                    description: "印2個蓄積後にチーム全員にNA/CA/PlungeDMG+16-32%",
+                    description: desc!("印2個蓄積後にチーム全員にNA/CA/PlungeDMG+16-32%"),
                     stat: BuffableStat::NormalAtkDmgBonus,
                     value: 0.16,
                     nightsoul_value: None,
@@ -177,7 +183,7 @@ pub const FREEDOM_SWORN: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "freedom_sworn_team_ca_dmg",
-                    description: "印2個蓄積後にチーム全員にNA/CA/PlungeDMG+16-32%",
+                    description: desc!("印2個蓄積後にチーム全員にNA/CA/PlungeDMG+16-32%"),
                     stat: BuffableStat::ChargedAtkDmgBonus,
                     value: 0.16,
                     nightsoul_value: None,
@@ -188,7 +194,7 @@ pub const FREEDOM_SWORN: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "freedom_sworn_team_plunge_dmg",
-                    description: "印2個蓄積後にチーム全員にNA/CA/PlungeDMG+16-32%",
+                    description: desc!("印2個蓄積後にチーム全員にNA/CA/PlungeDMG+16-32%"),
                     stat: BuffableStat::PlungingAtkDmgBonus,
                     value: 0.16,
                     nightsoul_value: None,
@@ -212,7 +218,9 @@ pub const HARAN_GEPPAKU_FUTSU: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "白月の一太刀",
         effect: PassiveEffect {
-            description: "元素DMG+12-24%。チームメンバーが元素スキルを使うと通常攻撃DMGアップ",
+            description: desc!(
+                "元素DMG+12-24%。チームメンバーが元素スキルを使うと通常攻撃DMGアップ"
+            ),
             buffs: &[StatBuff {
                 stat: BuffableStat::DmgBonus,
                 value: 0.12,
@@ -220,7 +228,7 @@ pub const HARAN_GEPPAKU_FUTSU: WeaponData = WeaponData {
             }],
             conditional_buffs: &[ConditionalBuff {
                 name: "haran_na_dmg",
-                description: "チームメンバーのスキル使用でNA DMG+12-24%（最大2スタック）",
+                description: desc!("チームメンバーのスキル使用でNA DMG+12-24%（最大2スタック）"),
                 stat: BuffableStat::NormalAtkDmgBonus,
                 value: 0.12,
                 nightsoul_value: None,
@@ -243,11 +251,13 @@ pub const KEY_OF_KHAJ_NISUT: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "砂漠の導きの鍵",
         effect: PassiveEffect {
-            description: "Conditional: HP上限に基づき元素熟知アップ。フルスタックでチーム全員にEM付与",
+            description: desc!(
+                "Conditional: HP上限に基づき元素熟知アップ。フルスタックでチーム全員にEM付与"
+            ),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "khaj_nisut_hp_em",
-                description: "HP上限×0.12-0.24%分をEMに加算",
+                description: desc!("HP上限×0.12-0.24%分をEMに加算"),
                 stat: BuffableStat::ElementalMastery,
                 value: 0.0012,
                 nightsoul_value: None,
@@ -274,7 +284,7 @@ pub const LIGHT_OF_FOLIAR_INCISION: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "葉に宿る白露",
         effect: PassiveEffect {
-            description: "CRIT Rate+4-8%。EMに基づきNA/SkillDMGアップ",
+            description: desc!("CRIT Rate+4-8%。EMに基づきNA/SkillDMGアップ"),
             buffs: &[StatBuff {
                 stat: BuffableStat::CritRate,
                 value: 0.04,
@@ -283,7 +293,7 @@ pub const LIGHT_OF_FOLIAR_INCISION: WeaponData = WeaponData {
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "foliar_em_normal_flat",
-                    description: "EM×120-240%分を通常攻撃フラットダメージに加算",
+                    description: desc!("EM×120-240%分を通常攻撃フラットダメージに加算"),
                     stat: BuffableStat::NormalAtkFlatDmg,
                     value: 1.20,
                     nightsoul_value: None,
@@ -301,7 +311,7 @@ pub const LIGHT_OF_FOLIAR_INCISION: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "foliar_em_skill_flat",
-                    description: "EM×120-240%分をスキルフラットダメージに加算",
+                    description: desc!("EM×120-240%分をスキルフラットダメージに加算"),
                     stat: BuffableStat::SkillFlatDmg,
                     value: 1.20,
                     nightsoul_value: None,
@@ -332,12 +342,12 @@ pub const LIGHTBEARING_MOONSHARD: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Lightbearing Moonshard",
         effect: PassiveEffect {
-            description: "月光の力でATK+24-48%/DMG+20-40%",
+            description: desc!("月光の力でATK+24-48%/DMG+20-40%"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "lightbearing_atk",
-                    description: "月光発動時にATK+24-48%",
+                    description: desc!("月光発動時にATK+24-48%"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.24,
                     nightsoul_value: None,
@@ -348,7 +358,7 @@ pub const LIGHTBEARING_MOONSHARD: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "lightbearing_dmg",
-                    description: "月光発動時にDMG+20-40%",
+                    description: desc!("月光発動時にDMG+20-40%"),
                     stat: BuffableStat::DmgBonus,
                     value: 0.20,
                     nightsoul_value: None,
@@ -372,7 +382,7 @@ pub const MISTSPLITTER_REFORGED: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "霧切の巴紋",
         effect: PassiveEffect {
-            description: "元素DMG+12-24%。霧切の巴紋を蓄積して追加元素DMGアップ",
+            description: desc!("元素DMG+12-24%。霧切の巴紋を蓄積して追加元素DMGアップ"),
             buffs: &[StatBuff {
                 stat: BuffableStat::DmgBonus,
                 value: 0.12,
@@ -380,7 +390,7 @@ pub const MISTSPLITTER_REFORGED: WeaponData = WeaponData {
             }],
             conditional_buffs: &[ConditionalBuff {
                 name: "mistsplitter_emblem",
-                description: "霧切の巴紋: 1/2/3スタックで元素DMG+8%/16%/28% (R1)",
+                description: desc!("霧切の巴紋: 1/2/3スタックで元素DMG+8%/16%/28% (R1)"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.08,
                 nightsoul_value: None,
@@ -403,12 +413,14 @@ pub const PEAK_PATROL_SONG: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Peak Patrol Song",
         effect: PassiveEffect {
-            description: "Ode to Flowers: スタックごとにDEF%/元素DMGアップ。2スタック時チームにDEFベース元素DMG付与",
+            description: desc!(
+                "Ode to Flowers: スタックごとにDEF%/元素DMGアップ。2スタック時チームにDEFベース元素DMG付与"
+            ),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "peak_patrol_self_def",
-                    description: "Ode to Flowers: DEF+8-16% per stack (max 2)",
+                    description: desc!("Ode to Flowers: DEF+8-16% per stack (max 2)"),
                     stat: BuffableStat::DefPercent,
                     value: 0.08,
                     nightsoul_value: None,
@@ -419,7 +431,9 @@ pub const PEAK_PATROL_SONG: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "peak_patrol_self_dmg",
-                    description: "Ode to Flowers: All Elemental DMG+10-20% per stack (max 2)",
+                    description: desc!(
+                        "Ode to Flowers: All Elemental DMG+10-20% per stack (max 2)"
+                    ),
                     stat: BuffableStat::AllElementalDmgBonus,
                     value: 0.10,
                     nightsoul_value: None,
@@ -430,7 +444,9 @@ pub const PEAK_PATROL_SONG: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "peak_patrol_team_dmg",
-                    description: "2 stacks: party All Elemental DMG based on 8-16% of DEF (cap 25.6-51.2%)",
+                    description: desc!(
+                        "2 stacks: party All Elemental DMG based on 8-16% of DEF (cap 25.6-51.2%)"
+                    ),
                     stat: BuffableStat::AllElementalDmgBonus,
                     value: 0.00008,
                     nightsoul_value: None,
@@ -461,7 +477,7 @@ pub const PRIMORDIAL_JADE_CUTTER: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "護国の無垢",
         effect: PassiveEffect {
-            description: "HP+20-40%。HP上限の1.2-2.4%分ATKアップ",
+            description: desc!("HP+20-40%。HP上限の1.2-2.4%分ATKアップ"),
             buffs: &[StatBuff {
                 stat: BuffableStat::HpPercent,
                 value: 0.20,
@@ -469,7 +485,7 @@ pub const PRIMORDIAL_JADE_CUTTER: WeaponData = WeaponData {
             }],
             conditional_buffs: &[ConditionalBuff {
                 name: "jade_cutter_hp_atk",
-                description: "HP上限の1.2%分ATKアップ（HP%に比例）",
+                description: desc!("HP上限の1.2%分ATKアップ（HP%に比例）"),
                 stat: BuffableStat::AtkFlat,
                 value: 0.012,
                 nightsoul_value: None,
@@ -496,7 +512,7 @@ pub const SKYWARD_BLADE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "天空の刃",
         effect: PassiveEffect {
-            description: "CRIT Rate+4-8%。元素爆発後にNA/CAの速度とDMGアップ",
+            description: desc!("CRIT Rate+4-8%。元素爆発後にNA/CAの速度とDMGアップ"),
             buffs: &[StatBuff {
                 stat: BuffableStat::CritRate,
                 value: 0.04,
@@ -517,7 +533,9 @@ pub const SPLENDOR_OF_TRANQUIL_WATERS: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "静水流転の輝き",
         effect: PassiveEffect {
-            description: "Skill DMG+8-16%。HP変動時にNA DMGアップ、NA命中時にSkill DMGアップ",
+            description: desc!(
+                "Skill DMG+8-16%。HP変動時にNA DMGアップ、NA命中時にSkill DMGアップ"
+            ),
             buffs: &[StatBuff {
                 stat: BuffableStat::SkillDmgBonus,
                 value: 0.08,
@@ -526,7 +544,7 @@ pub const SPLENDOR_OF_TRANQUIL_WATERS: WeaponData = WeaponData {
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "splendor_na_dmg",
-                    description: "HP変動時にNA DMG+8-16%（最大3スタック）",
+                    description: desc!("HP変動時にNA DMG+8-16%（最大3スタック）"),
                     stat: BuffableStat::NormalAtkDmgBonus,
                     value: 0.08,
                     nightsoul_value: None,
@@ -537,7 +555,7 @@ pub const SPLENDOR_OF_TRANQUIL_WATERS: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "splendor_skill_dmg",
-                    description: "NA命中時にSkill DMG+6-12%（最大3スタック）",
+                    description: desc!("NA命中時にSkill DMG+6-12%（最大3スタック）"),
                     stat: BuffableStat::SkillDmgBonus,
                     value: 0.06,
                     nightsoul_value: None,
@@ -561,12 +579,12 @@ pub const SUMMIT_SHAPER: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "金璋の頂に登る",
         effect: PassiveEffect {
-            description: "攻撃命中でATK+4-8%スタック（最大5）、シールド時は2倍",
+            description: desc!("攻撃命中でATK+4-8%スタック（最大5）、シールド時は2倍"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "summit_shaper_atk_stacks",
-                    description: "攻撃命中でATK+4-8%（1スタック）、最大5スタック",
+                    description: desc!("攻撃命中でATK+4-8%（1スタック）、最大5スタック"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.04,
                     nightsoul_value: None,
@@ -577,7 +595,7 @@ pub const SUMMIT_SHAPER: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "summit_shaper_shield_atk_stacks",
-                    description: "シールド時にATKスタック効果2倍分（追加ATK+4-8%/スタック）",
+                    description: desc!("シールド時にATKスタック効果2倍分（追加ATK+4-8%/スタック）"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.04,
                     nightsoul_value: None,
@@ -601,7 +619,7 @@ pub const URAKU_MISUGIRI: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "浮楽の御簾切り",
         effect: PassiveEffect {
-            description: "NA DMG+16-32%。DEFに基づき元素スキルDMGアップ",
+            description: desc!("NA DMG+16-32%。DEFに基づき元素スキルDMGアップ"),
             buffs: &[StatBuff {
                 stat: BuffableStat::NormalAtkDmgBonus,
                 value: 0.16,
@@ -609,7 +627,7 @@ pub const URAKU_MISUGIRI: WeaponData = WeaponData {
             }],
             conditional_buffs: &[ConditionalBuff {
                 name: "uraku_def_skill",
-                description: "DEF増加分×18-36%分をスキルDMGボーナスに加算",
+                description: desc!("DEF増加分×18-36%分をスキルDMGボーナスに加算"),
                 stat: BuffableStat::SkillDmgBonus,
                 value: 0.18,
                 nightsoul_value: None,
@@ -640,7 +658,9 @@ pub const AMENOMA_KAGEUCHI: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "天目影打の鍛造",
         effect: PassiveEffect {
-            description: "Conditional: 元素スキルで継承の印を獲得、元素爆発時にエネルギー回復",
+            description: desc!(
+                "Conditional: 元素スキルで継承の印を獲得、元素爆発時にエネルギー回復"
+            ),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -657,11 +677,11 @@ pub const BLACKCLIFF_LONGSWORD: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "追撃の一矢",
         effect: PassiveEffect {
-            description: "Conditional: 敵を倒すとATK+12%、30秒、3スタックまで",
+            description: desc!("Conditional: 敵を倒すとATK+12%、30秒、3スタックまで"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "blackcliff_longsword_atk",
-                description: "敵撃破ごとにATK+12-24%（最大3スタック）",
+                description: desc!("敵撃破ごとにATK+12-24%（最大3スタック）"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.12,
                 nightsoul_value: None,
@@ -684,12 +704,12 @@ pub const CALAMITY_OF_ESHU: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Calamity of Eshu",
         effect: PassiveEffect {
-            description: "Conditional: 元素反応時にスキルDMGとCRIT Rateがアップ",
+            description: desc!("Conditional: 元素反応時にスキルDMGとCRIT Rateがアップ"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "calamity_eshu_skill_dmg",
-                    description: "元素反応後にSkill DMG+20-40%",
+                    description: desc!("元素反応後にSkill DMG+20-40%"),
                     stat: BuffableStat::SkillDmgBonus,
                     value: 0.20,
                     nightsoul_value: None,
@@ -700,7 +720,7 @@ pub const CALAMITY_OF_ESHU: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "calamity_eshu_crit_rate",
-                    description: "元素反応後にCRIT Rate+6-12%",
+                    description: desc!("元素反応後にCRIT Rate+6-12%"),
                     stat: BuffableStat::CritRate,
                     value: 0.06,
                     nightsoul_value: None,
@@ -724,11 +744,11 @@ pub const CINNABAR_SPINDLE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "辰砂の紡錘",
         effect: PassiveEffect {
-            description: "元素スキルのDMGにDEFの40-80%分を加算",
+            description: desc!("元素スキルのDMGにDEFの40-80%分を加算"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "cinnabar_skill_def_flat",
-                description: "元素スキルのDMGにDEFの40-80%分を加算",
+                description: desc!("元素スキルのDMGにDEFの40-80%分を加算"),
                 stat: BuffableStat::SkillFlatDmg,
                 value: 0.40,
                 nightsoul_value: None,
@@ -755,7 +775,7 @@ pub const FAVONIUS_SWORD: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "順風の加護",
         effect: PassiveEffect {
-            description: "Conditional: 会心命中時に元素粒子を生成、12秒に1回",
+            description: desc!("Conditional: 会心命中時に元素粒子を生成、12秒に1回"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -772,7 +792,7 @@ pub const FESTERING_DESIRE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "腐植の剣",
         effect: PassiveEffect {
-            description: "Skill DMG+16-32%、Skill CRIT Rate+6-12%",
+            description: desc!("Skill DMG+16-32%、Skill CRIT Rate+6-12%"),
             buffs: &[StatBuff {
                 stat: BuffableStat::SkillDmgBonus,
                 value: 0.16,
@@ -780,7 +800,7 @@ pub const FESTERING_DESIRE: WeaponData = WeaponData {
             }],
             conditional_buffs: &[ConditionalBuff {
                 name: "festering_skill_cr",
-                description: "元素スキルのCRIT Rate+6-12%",
+                description: desc!("元素スキルのCRIT Rate+6-12%"),
                 stat: BuffableStat::CritRate,
                 value: 0.06,
                 nightsoul_value: None,
@@ -803,7 +823,7 @@ pub const FINALE_OF_THE_DEEP: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "深淵のフィナーレ",
         effect: PassiveEffect {
-            description: "ATK+12-24%。HP増減時にNA/CA/PlungeDMGアップ",
+            description: desc!("ATK+12-24%。HP増減時にNA/CA/PlungeDMGアップ"),
             buffs: &[StatBuff {
                 stat: BuffableStat::AtkPercent,
                 value: 0.12,
@@ -812,7 +832,7 @@ pub const FINALE_OF_THE_DEEP: WeaponData = WeaponData {
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "finale_deep_na_dmg",
-                    description: "HP増減時にNA DMG+12-24%",
+                    description: desc!("HP増減時にNA DMG+12-24%"),
                     stat: BuffableStat::NormalAtkDmgBonus,
                     value: 0.12,
                     nightsoul_value: None,
@@ -823,7 +843,7 @@ pub const FINALE_OF_THE_DEEP: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "finale_deep_ca_dmg",
-                    description: "HP増減時にCA DMG+12-24%",
+                    description: desc!("HP増減時にCA DMG+12-24%"),
                     stat: BuffableStat::ChargedAtkDmgBonus,
                     value: 0.12,
                     nightsoul_value: None,
@@ -834,7 +854,7 @@ pub const FINALE_OF_THE_DEEP: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "finale_deep_plunge_dmg",
-                    description: "HP増減時にPlunge DMG+12-24%",
+                    description: desc!("HP増減時にPlunge DMG+12-24%"),
                     stat: BuffableStat::PlungingAtkDmgBonus,
                     value: 0.12,
                     nightsoul_value: None,
@@ -858,12 +878,12 @@ pub const FLEUVE_CENDRE_FERRYMAN: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "灰燼の川の渡し守",
         effect: PassiveEffect {
-            description: "Conditional: 元素スキルのCRIT RateとER%がアップ",
+            description: desc!("Conditional: 元素スキルのCRIT RateとER%がアップ"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "fleuve_skill_cr",
-                    description: "元素スキル使用後にCRIT Rate+8-16%（スキルのみ）",
+                    description: desc!("元素スキル使用後にCRIT Rate+8-16%（スキルのみ）"),
                     stat: BuffableStat::CritRate,
                     value: 0.08,
                     nightsoul_value: None,
@@ -874,7 +894,7 @@ pub const FLEUVE_CENDRE_FERRYMAN: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "fleuve_energy_recharge",
-                    description: "元素スキル使用後にER+16-32%",
+                    description: desc!("元素スキル使用後にER+16-32%"),
                     stat: BuffableStat::EnergyRecharge,
                     value: 0.16,
                     nightsoul_value: None,
@@ -898,11 +918,11 @@ pub const FLUTE_OF_EZPITZAL: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Flute of Ezpitzal",
         effect: PassiveEffect {
-            description: "夜魂の加護状態で通常攻撃DMGにDEFの24-48%分を加算",
+            description: desc!("夜魂の加護状態で通常攻撃DMGにDEFの24-48%分を加算"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "flute_ezpitzal_def_flat",
-                description: "夜魂の加護状態で通常攻撃DMGにDEFの24-48%分を加算",
+                description: desc!("夜魂の加護状態で通常攻撃DMGにDEFの24-48%分を加算"),
                 stat: BuffableStat::NormalAtkFlatDmg,
                 value: 0.24,
                 nightsoul_value: None,
@@ -932,11 +952,11 @@ pub const IRON_STING: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "注入の刺突",
         effect: PassiveEffect {
-            description: "元素ダメージ命中時にDMG+6-12%、6秒、2スタックまで",
+            description: desc!("元素ダメージ命中時にDMG+6-12%、6秒、2スタックまで"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "iron_sting_dmg",
-                description: "元素ダメージ命中後、全DMG+6-12%（最大2スタック）",
+                description: desc!("元素ダメージ命中後、全DMG+6-12%（最大2スタック）"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.06,
                 nightsoul_value: None,
@@ -959,11 +979,11 @@ pub const KAGOTSURUBE_ISSHIN: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "名刀・籠釣瓶一心",
         effect: PassiveEffect {
-            description: "Conditional: NA/CA/Plunge命中時にATK+15%、8秒",
+            description: desc!("Conditional: NA/CA/Plunge命中時にATK+15%、8秒"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "kagotsurube_atk",
-                description: "NA/CA/Plunge命中時にATK+15%（イベント武器、精錬なし）",
+                description: desc!("NA/CA/Plunge命中時にATK+15%（イベント武器、精錬なし）"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.15,
                 nightsoul_value: None,
@@ -986,11 +1006,11 @@ pub const LIONS_ROAR: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "獅子の咆哮",
         effect: PassiveEffect {
-            description: "炎/雷の影響を受けた敵にDMG+20-36%",
+            description: desc!("炎/雷の影響を受けた敵にDMG+20-36%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "lions_roar_dmg",
-                description: "炎/雷元素の影響下の敵へのDMG+20-36%",
+                description: desc!("炎/雷元素の影響下の敵へのDMG+20-36%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.20,
                 nightsoul_value: None,
@@ -1013,11 +1033,11 @@ pub const MOONWEAVERS_DAWN: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Moonweaver's Dawn",
         effect: PassiveEffect {
-            description: "Conditional: 元素スキルまたは元素爆発の命中時にDMGバフ獲得",
+            description: desc!("Conditional: 元素スキルまたは元素爆発の命中時にDMGバフ獲得"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "moonweavers_dawn_dmg",
-                description: "Skill/Burst命中後にDMG+16-32%",
+                description: desc!("Skill/Burst命中後にDMG+16-32%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.16,
                 nightsoul_value: None,
@@ -1040,11 +1060,11 @@ pub const PRIZED_ISSHIN_BLADE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "名刀一心",
         effect: PassiveEffect {
-            description: "元素スキル命中後にATK+12-24%",
+            description: desc!("元素スキル命中後にATK+12-24%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "prized_isshin_atk",
-                description: "元素スキル命中後にATK+12-24%",
+                description: desc!("元素スキル命中後にATK+12-24%"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.12,
                 nightsoul_value: None,
@@ -1069,12 +1089,12 @@ pub const PROTOTYPE_RANCOUR: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "砕石の試練",
         effect: PassiveEffect {
-            description: "Conditional: NA/CA命中時にATK/DEF+4%、6秒、4スタックまで",
+            description: desc!("Conditional: NA/CA命中時にATK/DEF+4%、6秒、4スタックまで"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "prototype_rancour_atk",
-                    description: "NA/CA命中時にATK+4-8%（最大4スタック）",
+                    description: desc!("NA/CA命中時にATK+4-8%（最大4スタック）"),
                     stat: BuffableStat::AtkPercent,
                     value: 0.04,
                     nightsoul_value: None,
@@ -1085,7 +1105,7 @@ pub const PROTOTYPE_RANCOUR: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "prototype_rancour_def",
-                    description: "NA/CA命中時にDEF+4-8%（最大4スタック）",
+                    description: desc!("NA/CA命中時にDEF+4-8%（最大4スタック）"),
                     stat: BuffableStat::DefPercent,
                     value: 0.04,
                     nightsoul_value: None,
@@ -1109,11 +1129,13 @@ pub const ROYAL_LONGSWORD: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "集中",
         effect: PassiveEffect {
-            description: "ダメージ命中で会心でなければCRIT Rate+8%×5スタック（最大40-80%）",
+            description: desc!("ダメージ命中で会心でなければCRIT Rate+8%×5スタック（最大40-80%）"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "royal_longsword_cr",
-                description: "ダメージ命中で会心でなければCRIT Rate+8%×5スタック（最大40-80%）",
+                description: desc!(
+                    "ダメージ命中で会心でなければCRIT Rate+8%×5スタック（最大40-80%）"
+                ),
                 stat: BuffableStat::CritRate,
                 value: 0.40,
                 nightsoul_value: None,
@@ -1136,7 +1158,7 @@ pub const SACRIFICIAL_SWORD: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "気定神閑",
         effect: PassiveEffect {
-            description: "Conditional: 元素スキル命中時に40%の確率でCD即リセット、30秒に1回",
+            description: desc!("Conditional: 元素スキル命中時に40%の確率でCD即リセット、30秒に1回"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -1153,11 +1175,11 @@ pub const SAPWOOD_BLADE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "森林の活力",
         effect: PassiveEffect {
-            description: "Conditional: 草元素反応時に葉を生成、拾うとEM+60、12秒",
+            description: desc!("Conditional: 草元素反応時に葉を生成、拾うとEM+60、12秒"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "sapwood_blade_em",
-                description: "草元素反応後に葉を拾うとEM+60-120",
+                description: desc!("草元素反応後に葉を拾うとEM+60-120"),
                 stat: BuffableStat::ElementalMastery,
                 value: 60.0,
                 nightsoul_value: None,
@@ -1180,11 +1202,11 @@ pub const SERENITYS_CALL: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Serenity's Call",
         effect: PassiveEffect {
-            description: "元素スキル命中後にDMG+8-16%",
+            description: desc!("元素スキル命中後にDMG+8-16%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "serenitys_call_dmg",
-                description: "元素スキル命中後にDMG+8-16%",
+                description: desc!("元素スキル命中後にDMG+8-16%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.08,
                 nightsoul_value: None,
@@ -1207,11 +1229,11 @@ pub const STURDY_BONE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "Sturdy Bone",
         effect: PassiveEffect {
-            description: "スプリント後にNA DMG+16-32%",
+            description: desc!("スプリント後にNA DMG+16-32%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "sturdy_bone_na_dmg",
-                description: "スプリント後にNA DMG+16-32%",
+                description: desc!("スプリント後にNA DMG+16-32%"),
                 stat: BuffableStat::NormalAtkDmgBonus,
                 value: 0.16,
                 nightsoul_value: None,
@@ -1234,7 +1256,7 @@ pub const SWORD_OF_DESCENSION: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "降臨の剣",
         effect: PassiveEffect {
-            description: "Conditional: 旅人が装備時にNA/CA命中時50%で追加ダメージ、ATK+66",
+            description: desc!("Conditional: 旅人が装備時にNA/CA命中時50%で追加ダメージ、ATK+66"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -1251,12 +1273,14 @@ pub const SWORD_OF_NARZISSENKREUZ: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "ナルツィッセンクロイツの剣",
         effect: PassiveEffect {
-            description: "Conditional: 装備者が「始まりの大いなる冒険」の影響を受けると元素スキル/元素爆発DMGアップ",
+            description: desc!(
+                "Conditional: 装備者が「始まりの大いなる冒険」の影響を受けると元素スキル/元素爆発DMGアップ"
+            ),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "narzissenkreuz_skill_dmg",
-                    description: "冒険状態時にSkill DMG+32-64%",
+                    description: desc!("冒険状態時にSkill DMG+32-64%"),
                     stat: BuffableStat::SkillDmgBonus,
                     value: 0.32,
                     nightsoul_value: None,
@@ -1267,7 +1291,7 @@ pub const SWORD_OF_NARZISSENKREUZ: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "narzissenkreuz_burst_dmg",
-                    description: "冒険状態時にBurst DMG+32-64%",
+                    description: desc!("冒険状態時にBurst DMG+32-64%"),
                     stat: BuffableStat::BurstDmgBonus,
                     value: 0.32,
                     nightsoul_value: None,
@@ -1291,11 +1315,11 @@ pub const THE_ALLEY_FLASH: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "裏路地の閃光",
         effect: PassiveEffect {
-            description: "DMG+12-24%。ダメージを受けると効果消失、5秒後に再発動",
+            description: desc!("DMG+12-24%。ダメージを受けると効果消失、5秒後に再発動"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "alley_flash_dmg",
-                description: "DMG+12-24%（被弾で消失、5秒後に再発動）",
+                description: desc!("DMG+12-24%（被弾で消失、5秒後に再発動）"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.12,
                 nightsoul_value: None,
@@ -1318,7 +1342,7 @@ pub const THE_BLACK_SWORD: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "黒曜の輝き",
         effect: PassiveEffect {
-            description: "NA/CA DMG+20-40%。NA/CA会心時にHP回復",
+            description: desc!("NA/CA DMG+20-40%。NA/CA会心時にHP回復"),
             buffs: &[
                 StatBuff {
                     stat: BuffableStat::NormalAtkDmgBonus,
@@ -1346,11 +1370,11 @@ pub const THE_DOCKHANDS_ASSISTANT: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "埠頭の助手",
         effect: PassiveEffect {
-            description: "Conditional: 元素反応時にEM+40、8秒、3スタックまで",
+            description: desc!("Conditional: 元素反応時にEM+40、8秒、3スタックまで"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "dockhands_em",
-                description: "元素反応ごとにEM+40-80（最大3スタック）",
+                description: desc!("元素反応ごとにEM+40-80（最大3スタック）"),
                 stat: BuffableStat::ElementalMastery,
                 value: 40.0,
                 nightsoul_value: None,
@@ -1373,7 +1397,7 @@ pub const THE_FLUTE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "和弦の調べ",
         effect: PassiveEffect {
-            description: "Conditional: NA/CA命中時に和音を蓄積、5つでATK100%のDMG",
+            description: desc!("Conditional: NA/CA命中時に和音を蓄積、5つでATK100%のDMG"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -1390,11 +1414,11 @@ pub const TOUKABOU_SHIGURE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "唐笠の時雨",
         effect: PassiveEffect {
-            description: "落下攻撃命中後にDMG+16-32%",
+            description: desc!("落下攻撃命中後にDMG+16-32%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "toukabou_dmg",
-                description: "落下攻撃命中後にDMG+16-32%",
+                description: desc!("落下攻撃命中後にDMG+16-32%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.16,
                 nightsoul_value: None,
@@ -1417,7 +1441,9 @@ pub const WOLF_FANG: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "狼牙",
         effect: PassiveEffect {
-            description: "Skill/Burst DMG+16-32%。Skill/Burst命中時にDEF-4%、6秒、4スタックまで",
+            description: desc!(
+                "Skill/Burst DMG+16-32%。Skill/Burst命中時にDEF-4%、6秒、4スタックまで"
+            ),
             buffs: &[
                 StatBuff {
                     stat: BuffableStat::SkillDmgBonus,
@@ -1432,7 +1458,7 @@ pub const WOLF_FANG: WeaponData = WeaponData {
             ],
             conditional_buffs: &[ConditionalBuff {
                 name: "wolf_fang_def_reduction",
-                description: "Skill/Burst命中時に敵DEF-4-8%（最大4スタック）",
+                description: desc!("Skill/Burst命中時に敵DEF-4-8%（最大4スタック）"),
                 stat: BuffableStat::DefReduction,
                 value: 0.04,
                 nightsoul_value: None,
@@ -1455,12 +1481,12 @@ pub const XIPHOS_MOONLIGHT: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "クシフォスの月光",
         effect: PassiveEffect {
-            description: "Conditional: EMに基づきERアップ。チームメンバーにもER付与",
+            description: desc!("Conditional: EMに基づきERアップ。チームメンバーにもER付与"),
             buffs: &[],
             conditional_buffs: &[
                 ConditionalBuff {
                     name: "xiphos_self_er",
-                    description: "EM×0.036-0.072%分のERを自身に付与",
+                    description: desc!("EM×0.036-0.072%分のERを自身に付与"),
                     stat: BuffableStat::EnergyRecharge,
                     value: 0.00036,
                     nightsoul_value: None,
@@ -1475,7 +1501,7 @@ pub const XIPHOS_MOONLIGHT: WeaponData = WeaponData {
                 },
                 ConditionalBuff {
                     name: "xiphos_team_er",
-                    description: "自身のER付与量の30%をチームメンバーに付与",
+                    description: desc!("自身のER付与量の30%をチームメンバーに付与"),
                     stat: BuffableStat::EnergyRecharge,
                     value: 0.000108,
                     nightsoul_value: None,
@@ -1507,11 +1533,11 @@ pub const COOL_STEEL: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "急凍の恩恵",
         effect: PassiveEffect {
-            description: "Conditional: 水/氷の影響を受けた敵にDMG+12%",
+            description: desc!("Conditional: 水/氷の影響を受けた敵にDMG+12%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "cool_steel_dmg",
-                description: "水/氷の影響を受けた敵にDMG+12-24%",
+                description: desc!("水/氷の影響を受けた敵にDMG+12-24%"),
                 stat: BuffableStat::DmgBonus,
                 value: 0.12,
                 nightsoul_value: None,
@@ -1534,11 +1560,11 @@ pub const DARK_IRON_SWORD: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "過負荷",
         effect: PassiveEffect {
-            description: "Conditional: 雷元素反応時にATK+20%、12秒",
+            description: desc!("Conditional: 雷元素反応時にATK+20%、12秒"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "dark_iron_atk",
-                description: "雷元素反応後にATK+20-40%",
+                description: desc!("雷元素反応後にATK+20-40%"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.20,
                 nightsoul_value: None,
@@ -1561,7 +1587,7 @@ pub const FILLET_BLADE: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "鋭利な一刀",
         effect: PassiveEffect {
-            description: "Conditional: 命中時に50%の確率でATK240%の追加ダメージ、15秒に1回",
+            description: desc!("Conditional: 命中時に50%の確率でATK240%の追加ダメージ、15秒に1回"),
             buffs: &[],
             conditional_buffs: &[],
         },
@@ -1578,11 +1604,11 @@ pub const HARBINGER_OF_DAWN: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "夜明けの曙光",
         effect: PassiveEffect {
-            description: "Conditional: HP90%以上でCRIT Rate+14%",
+            description: desc!("Conditional: HP90%以上でCRIT Rate+14%"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "harbinger_crit_rate",
-                description: "HP90%以上でCRIT Rate+14-28%",
+                description: desc!("HP90%以上でCRIT Rate+14-28%"),
                 stat: BuffableStat::CritRate,
                 value: 0.14,
                 nightsoul_value: None,
@@ -1605,11 +1631,11 @@ pub const SKYRIDER_SWORD: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "決意",
         effect: PassiveEffect {
-            description: "Conditional: 元素爆発後にNA/CA ATK+12%、15秒",
+            description: desc!("Conditional: 元素爆発後にNA/CA ATK+12%、15秒"),
             buffs: &[],
             conditional_buffs: &[ConditionalBuff {
                 name: "skyrider_sword_atk",
-                description: "元素爆発後にATK+12-24%",
+                description: desc!("元素爆発後にATK+12-24%"),
                 stat: BuffableStat::AtkPercent,
                 value: 0.12,
                 nightsoul_value: None,
@@ -1632,7 +1658,7 @@ pub const TRAVELERS_HANDY_SWORD: WeaponData = WeaponData {
     passive: Some(WeaponPassive {
         name: "旅の道標",
         effect: PassiveEffect {
-            description: "Conditional: 元素オーブ/元素粒子を獲得時にHP回復",
+            description: desc!("Conditional: 元素オーブ/元素粒子を獲得時にHP回復"),
             buffs: &[],
             conditional_buffs: &[],
         },

--- a/crates/good/Cargo.toml
+++ b/crates/good/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["game-engines", "parser-implementations"]
 readme = "README.md"
 
 [dependencies]
-genshin-calc-core = { path = "../core", version = "0.5.11" }
-genshin-calc-data = { path = "../data", version = "0.5.11" }
+genshin-calc-core = { path = "../core", version = "0.5.11", default-features = false }
+genshin-calc-data = { path = "../data", version = "0.5.11", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/crates/good/Cargo.toml
+++ b/crates/good/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genshin-calc-good"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -12,8 +12,8 @@ categories = ["game-engines", "parser-implementations"]
 readme = "README.md"
 
 [dependencies]
-genshin-calc-core = { path = "../core", version = "0.5.11", default-features = false }
-genshin-calc-data = { path = "../data", version = "0.5.11", default-features = false }
+genshin-calc-core = { path = "../core", version = "0.5.12", default-features = false }
+genshin-calc-data = { path = "../data", version = "0.5.12", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genshin-calc-wasm"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2024"
 description = "WASM bindings for genshin-calc damage calculator"
 license = "MIT"
@@ -15,9 +15,9 @@ wasm-opt = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-genshin-calc-core = { version = "0.5.11", path = "../core", default-features = false }
-genshin-calc-data = { version = "0.5.11", path = "../data", default-features = false }
-genshin-calc-good = { version = "0.5.11", path = "../good" }
+genshin-calc-core = { version = "0.5.12", path = "../core", default-features = false }
+genshin-calc-data = { version = "0.5.12", path = "../data", default-features = false }
+genshin-calc-good = { version = "0.5.12", path = "../good" }
 wasm-bindgen = "0.2"
 serde-wasm-bindgen = "0.6"
 serde = { version = "1", features = ["derive"] }

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -8,12 +8,15 @@ authors = ["kotenbu135"]
 repository = "https://github.com/kotenbu135/genshin-calc"
 rust-version = "1.85"
 
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-genshin-calc-core = { version = "0.5.11", path = "../core" }
-genshin-calc-data = { version = "0.5.11", path = "../data" }
+genshin-calc-core = { version = "0.5.11", path = "../core", default-features = false }
+genshin-calc-data = { version = "0.5.11", path = "../data", default-features = false }
 genshin-calc-good = { version = "0.5.11", path = "../good" }
 wasm-bindgen = "0.2"
 serde-wasm-bindgen = "0.6"

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PKG_DIR="$ROOT_DIR/crates/wasm/pkg"
+WASM_FILE="$PKG_DIR/genshin_calc_wasm_bg.wasm"
+
+TARGET="${1:-web}"
+
+echo "==> Building WASM (target: $TARGET)..."
+wasm-pack build "$ROOT_DIR/crates/wasm" --release --target "$TARGET"
+
+if command -v wasm-opt >/dev/null 2>&1; then
+    echo "==> Optimizing with wasm-opt -Oz..."
+    wasm-opt -Oz \
+        --enable-bulk-memory \
+        --enable-nontrapping-float-to-int \
+        "$WASM_FILE" -o "$WASM_FILE"
+    echo "    Done."
+else
+    echo "==> wasm-opt not found, skipping. Install with: cargo install wasm-opt"
+fi
+
+RAW_SIZE=$(stat -c%s "$WASM_FILE" 2>/dev/null || stat -f%z "$WASM_FILE")
+GZ_SIZE=$(gzip -c "$WASM_FILE" | wc -c)
+printf "==> Result: %d KB raw / %d KB gzip\n" $((RAW_SIZE / 1024)) $((GZ_SIZE / 1024))


### PR DESCRIPTION
## Summary
- `descriptions` feature gate（default有効）を core/data crate に追加し、WASM ビルドでは無効化して説明文字列を除去
- release profile 最適化（LTO, opt-level=z, codegen-units=1, strip=true）を追加
- `scripts/build-wasm.sh` を追加（wasm-pack + system wasm-opt -Oz の自動実行）

## WASM size comparison

|  | Raw | Gzip |
|---|---|---|
| Before | 737 KB | 306 KB |
| After | **649 KB** | **273 KB** |
| Delta | **-88 KB (-12%)** | **-33 KB (-11%)** |

## Test plan
- [x] `cargo test --workspace` all pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `scripts/build-wasm.sh` produces optimized WASM
- [x] Library users unaffected (descriptions enabled by default)