### PR TITLE
Add character verification reports for Dendro and Geo

### DIFF
--- a/docs/verification/dendro.md
+++ b/docs/verification/dendro.md
@@ -1,0 +1,101 @@
+# Dendro Character Verification
+
+Verified against: `honeyhunter-mirror/md/characters/`
+Scope: 倍率、スキル効果、バフ/デバフ、固有天賦、凸効果（追加ダメージ・元素チャージ系は除外）
+Excluded: 追加ダメージ、元素チャージ、クールタイム短縮、回復量/シールド量、スタミナ
+
+## Summary
+
+| Character | Scaling | Passives | Constellations | Status |
+|-----------|---------|----------|----------------|--------|
+| Alhaitham | OK | OK | OK | PASS |
+| Baizhu | OK | OK（対象範囲） | OK（対象範囲） | PASS |
+| Collei | OK | OK（対象範囲） | OK（対象範囲） | PASS |
+| Emilie | OK | OK | OK | PASS |
+| Kaveh | OK | OK（対象範囲） | OK（対象範囲） | PASS |
+| Kinich | OK | OK（対象範囲） | OK（対象範囲） | PASS |
+| Kirara | OK | **MISSING** (A4) | OK | FAIL |
+| Lauma | OK | OK | OK | PASS |
+| Nahida | OK | **SPEC GAP** (A1は最高EM参照→実装は自己EM近似) | OK（対象範囲） | FAIL |
+| Nefer | OK | OK（対象範囲） | OK（対象範囲） | PASS |
+| Tighnari | OK | OK | OK | PASS |
+| Traveler (Dendro) | OK | OK（対象範囲） | OK（対象範囲） | PASS |
+| Yaoyao | OK | OK（対象範囲） | OK（対象範囲） | PASS |
+
+**Bug / Spec-gap count: 2**
+- Missing implementation: 1 (Kirara A4)
+- Approximation gap: 1 (Nahida A1 highest party EM simplification)
+
+---
+
+## Issues
+
+### 1) Kirara A4 が未実装（TODOコメントのみ）
+
+- 対象コード: `crates/data/src/talent_buffs/dendro.rs`
+  - `KIRARA_BUFFS` セクションで A4 が `TODO` としてスキップされている。
+- Mirror仕様: `honeyhunter-mirror/md/characters/momoka_061.md`
+  - A4はHP基準でスキル/爆発系に影響する効果。
+- 影響: 綺良々のA4由来火力寄与が計算に入らない。
+
+### 2) Nahida A1 は仕様上「チーム最高EM」参照だが、実装は自己EMベース近似
+
+- 対象コード: `crates/data/src/talent_buffs/dendro.rs`
+  - `Compassion Illuminated` のコメントで、実装が単体評価時の近似であることを明示。
+- Mirror仕様: `honeyhunter-mirror/md/characters/nahida_073.md`
+  - A1は「領域内キャラに、チーム内最高元素熟知の25%（上限250）」。
+- 影響: ナヒーダ非場/他キャラEM主軸編成で配布EMの差異が出る可能性。
+
+---
+
+## Character-by-character Notes (対象範囲のみ)
+
+### Alhaitham
+- A4 (EM→DMG 0.1%/最大100%)、C2/C4/C6のバフ定義は実装済み。
+
+### Baizhu
+- A4（反応別係数: 燃焼/開花/超開花/烈開花/超激化/草激化/月開花）が実装済み。
+- C4 EM+80 実装済み。
+
+### Collei
+- C4 EM配布（自分以外）、C6草ダメ+35% 実装済み。
+
+### Emilie
+- A4（総攻撃力依存DMG%）、C1/C2 実装済み。
+
+### Kaveh
+- A4 EMスタック、Burst中の開花ダメージ補正、C4開花+60% 実装済み。
+
+### Kinich
+- C2草耐性-30% / 自己DMG+100%、C4爆発+70% 実装済み。
+
+### Kirara
+- C6全元素ダメ+12% 実装済み。
+- A4は未実装（Issue #1）。
+
+### Lauma
+- A4（EM依存スキルDMG%）およびC2/C6（月開花ダメージ）実装済み。
+
+### Nahida
+- C2/C4は実装済み。
+- A1は仕様簡略化（Issue #2）。
+
+### Nefer
+- C2/C4/C6（対象範囲内）実装済み。
+
+### Tighnari
+- A1/A4、C1/C2/C4のバフ実装済み。
+
+### Traveler (Dendro)
+- A4 EM+60、C6草ダメ+12% 実装済み。
+
+### Yaoyao
+- C1草ダメ配布、C4 HP依存EM（上限120）実装済み。
+
+---
+
+## Suggested Fixes (shortlist)
+
+1. `KIRARA_BUFFS` のA4 TODOを実装し、HP依存のスキル/爆発寄与を反映する。  
+2. Nahida A1はチーム最高EM参照に寄せる（TeamBuilder文脈で最高EM入力、または近似である旨をより明示）。
+

--- a/docs/verification/geo.md
+++ b/docs/verification/geo.md
@@ -1,0 +1,144 @@
+# Geo Character Verification
+
+Verified against: `honeyhunter-mirror/md/characters/`
+Scope: 倍率、スキル効果、バフ/デバフ、固有天賦、凸効果（追加ダメージ系・元素チャージ系は除外）
+Excluded: 追加ダメージ（flat追加ヒット系）、元素チャージ、クールタイム短縮、シールド量/回復量、スタミナ、継続時間
+
+## Summary
+
+| Character | Scaling | Passives | Constellations | Status |
+|-----------|---------|----------|----------------|--------|
+| Albedo | OK | OK（除外項目あり） | OK | PASS |
+| Chiori | OK | OK | OK | PASS |
+| Gorou | OK | **MISSING** (A1 DEF+25%) | **SPEC GAP** (C6 Geo限定会心ダメージを全体会心ダメとして実装) | FAIL |
+| Illuga | OK（倍率定義は存在） | **SPEC GAP** (A4未実装コメントのみ) | 部分実装 | FAIL |
+| Itto | OK | OK | OK | PASS |
+| Kachina | OK | OK | OK | PASS |
+| Navia | OK | OK | OK（対象範囲内） | PASS |
+| Ningguang | OK | OK | OK（対象範囲内） | PASS |
+| Noelle | OK | OK（除外項目あり） | OK（対象範囲内） | PASS |
+| Xilonen | OK | **MISSING** (A4 DEF+20%) | OK（対象範囲内） | FAIL |
+| Yun Jin | OK | **MISSING** (A4 Breaking Conventions) | OK（対象範囲内） | FAIL |
+| Zhongli | OK | OK（除外項目あり） | OK（対象範囲内） | PASS |
+| Zibai | OK（対象範囲） | OK（対象範囲） | OK（対象範囲） | PASS |
+
+**Bug / Spec-gap count: 5**
+- Missing buffs: 3 (Gorou A1, Yun Jin A4, Xilonen A4)
+- Implementation approximation gap: 2 (Gorou C6, Illuga A4)
+
+---
+
+## Issues
+
+### 1) Gorou A1「風雨を恐れず」(DEF+25%) が未実装
+
+- Mirror: `honeyhunter-mirror/md/characters/gorou_055.md`
+  - `After using Juuga: Forward Unto Victory, all nearby party members' DEF is increased by 25% for 12s.`
+- 現状 `crates/data/src/talent_buffs/geo.rs` の `GOROU_BUFFS` には A1 の `DefPercent +0.25` が存在しない。
+- 影響: ゴロー編成の防御参照キャラ（雲菫/ノエル/荒瀧など）で最終ダメージが過小評価される。
+
+### 2) Yun Jin A4「独立嶄然」未実装
+
+- Mirror: `honeyhunter-mirror/md/characters/yunjin_064.md`
+  - `Flying Cloud Flag Formation` の通常攻撃ダメージ加算を、編成元素種類に応じてさらに `2.5/5/7.5/11.5% DEF` 上乗せ。
+- 現状 `crates/data/src/talent_buffs/geo.rs` の `YUN_JIN_BUFFS` は Burst本体/C2/C4のみで、A4追加係数が未実装。
+- 影響: 雲菫の主用途（通常攻撃サポート）の中核バフが不足。
+
+### 3) Xilonen A4「Portable Armored Sheath」DEF+20% 未実装
+
+- Mirror: `honeyhunter-mirror/md/characters/xilonen_103.md`
+  - `when nearby party members trigger a Nightsoul Burst, Xilonen's DEF is increased by 20% for 15s.`
+- 現状 `crates/data/src/talent_buffs/geo.rs` の `XILONEN_BUFFS` には A4由来の `DefPercent +0.20 (OnlySelf)` が存在しない。
+- 影響: シロネン自身DEF参照（スキル由来耐性デバフ運用やC4加算系計算）で乖離。
+
+### 4) Gorou C6 は「岩元素ダメージの会心ダメージ」なのに、実装は全会心ダメージとして扱う近似
+
+- Mirror: `honeyhunter-mirror/md/characters/gorou_055.md`
+  - C6は **Geo DMG のみ** に対する CRIT DMG +10/20/40%。
+- 現状実装: `BuffableStat::CritDmg` で全属性に適用される形。
+- 影響: 岩元素以外の会心ダメージにも誤って上乗せされる可能性。
+
+### 5) Illuga A4 が未実装（コードコメントのみ）
+
+- Mirror: `honeyhunter-mirror/md/characters/illuga_127.md`
+  - A4は編成条件に応じた Geo DMG 系強化効果。
+- 現状 `crates/data/src/talent_buffs/geo.rs` に `TODO` コメントのみで有効な `TalentBuffDef` 不在。
+- 影響: イルーガ運用時の主要パッシブが反映されない。
+
+---
+
+## Character-by-character Notes (対象範囲のみ)
+
+### Albedo
+- 倍率テーブル: 実装値とmirror記載の主要倍率は一致。
+- A4 (EM+125) 実装済み。
+- C4/C6 実装済み（対象範囲内）。
+
+### Chiori
+- 倍率テーブル: 実装値とmirror記載は一致。
+- A4 (Geo DMG+20%) 実装済み。
+- C6通常攻撃フラット加算（DEF参照）実装済み。
+
+### Gorou
+- 倍率テーブル: 通常/スキル/爆発値は一致。
+- Skill DEF固定値スケーリング、Geo DMG+15% は実装あり。
+- A1 DEF+25% 未実装（Issue #1）。
+- C6の属性限定条件が近似化（Issue #4）。
+
+### Illuga
+- 倍率テーブル: キャラデータ側には定義あり。
+- A1（CR/CD/EM）実装済み。
+- A4未実装（Issue #5）。
+
+### Itto
+- 倍率テーブル: 実装値はmirror記載と整合。
+- A4（重撃DEF参照加算）実装済み。
+- C4/C6 実装済み。
+
+### Kachina
+- 倍率テーブル: 実装値は整合。
+- A4 Geo DMG+20% 実装済み。
+- C4 DEFバフ（最大値）実装済み。
+
+### Navia
+- 倍率テーブル: 対象倍率は整合。
+- A1通常/重撃/落下 +40% 実装済み。
+- A4攻撃力バフ（最大40%）実装済み。
+- C2/C4 実装済み。
+
+### Ningguang
+- 倍率テーブル: 実装値は整合。
+- A4「璇璣屏通過で岩ダメ+12%」実装済み。
+
+### Noelle
+- 倍率テーブル: 通常/スキル/爆発の主要値は整合。
+- Burst DEF→ATK変換 実装済み。
+- C2/C6 実装済み。
+
+### Xilonen
+- 倍率テーブル: 主要倍率および耐性低下スケールは整合。
+- C2/C4 実装済み（雷効果は対象外）。
+- A4 DEF+20% 未実装（Issue #3）。
+
+### Yun Jin
+- 倍率テーブル: スキル・爆発係数は整合。
+- Burst通常攻撃加算、C2/C4 実装済み。
+- A4 `Breaking Conventions` 未実装（Issue #2）。
+
+### Zhongli
+- 倍率テーブル: 実装値は整合。
+- Jade Shield全耐性-20%（元素/物理）実装済み。
+
+### Zibai
+- 対象範囲（バフ/デバフ・凸）に関して、実装との明確な不一致は確認されず。
+
+---
+
+## Suggested Fixes (shortlist)
+
+1. `GOROU_BUFFS` に A1 DEF+25% (`BuffableStat::DefPercent`, Team, A1) を追加。  
+2. `YUN_JIN_BUFFS` に A4追加係数（編成元素種類条件つき）を追加。  
+3. `XILONEN_BUFFS` に A4 DEF+20% (`OnlySelf`, A4, 条件付きトグル可) を追加。  
+4. Gorou C6は Geo限定会心ダメージとして扱えるstat拡張、または明示的な「仕様近似」注記を追加。  
+5. Illuga A4をTODO解除し、専用メカニクスまたは近似実装を追加。
+


### PR DESCRIPTION
### Motivation

- Add verification artifacts that compare implemented talent/buff data against the `honeyhunter-mirror` reference for Dendro and Geo characters to surface missing implementations and approximations. 
- Provide a concise actionable list of issues and suggested fixes so data maintainers can prioritize corrections to talent buff logic.
- Capture per-character notes to document scope, exclusions, and the concrete impact of each discrepancy for easier triage.

### Description

- Add `docs/verification/dendro.md` which summarizes verification results for Dendro characters, lists identified issues (Kirara A4 missing, Nahida A1 approximation), per-character notes, and suggested fixes. 
- Add `docs/verification/geo.md` which summarizes verification results for Geo characters, lists identified issues (missing A1/A4 buffs for Gorou/Yun Jin/Xilonen and a Gorou C6 approximation, Illuga A4 TODO), per-character notes, and suggested fixes. 
- Both files document verification scope and exclusions, count bug/spec-gap items, and point to the relevant `crates/data/src/talent_buffs/*.rs` sections for follow-up.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da521c328083288237b889e15a3cbe)