### PR TITLE
feat(core): expose MoonsignContext via TeamResolveResult (#142)

### DIFF
--- a/crates/core/src/enemy.rs
+++ b/crates/core/src/enemy.rs
@@ -744,6 +744,7 @@ mod tests {
             buffs_provided: vec![],
             is_moonsign: false,
             can_nightsoul: false,
+            moonsign_benediction: None,
         };
 
         let support = TeamMember {
@@ -786,6 +787,7 @@ mod tests {
             ],
             is_moonsign: false,
             can_nightsoul: false,
+            moonsign_benediction: None,
         };
 
         let team = vec![dps, support];

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -134,10 +134,11 @@ pub use lunar::{
     DirectLunarInput, LunarInput, LunarResult, calculate_direct_lunar, calculate_lunar,
 };
 pub use moonsign::{
-    LunarContribution, MoonsignBenediction, MoonsignContext, MoonsignLevel, MoonsignTalentEffect,
-    MoonsignTalentEnhancement, NonMoonsignLunarBuff, apply_moonsign_enhancements,
-    calculate_lunar_team, calculate_non_moonsign_bonus, determine_moonsign_level,
-    non_moonsign_scaling, resolve_moonsign_context, select_non_moonsign_buff,
+    LunarContribution, MoonsignBenediction, MoonsignBenedictionSpec, MoonsignContext,
+    MoonsignLevel, MoonsignTalentEffect, MoonsignTalentEnhancement, NonMoonsignLunarBuff,
+    apply_moonsign_enhancements, calculate_lunar_team, calculate_non_moonsign_bonus,
+    determine_moonsign_level, non_moonsign_scaling, resolve_moonsign_context,
+    select_non_moonsign_buff,
 };
 pub use reaction::{Reaction, ReactionCategory, determine_reaction};
 pub use resonance::{

--- a/crates/core/src/moonsign.rs
+++ b/crates/core/src/moonsign.rs
@@ -28,6 +28,41 @@ pub struct MoonsignBenediction {
     pub enabled_reactions: Vec<Reaction>,
 }
 
+/// Scaling specification for a Moonsign Benediction passive, attached to a
+/// [`crate::TeamMember`]. The final `base_dmg_bonus` is derived from the
+/// member's own stats at team resolution time.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MoonsignBenedictionSpec {
+    /// Lunar reaction types this character enables.
+    pub enabled_reactions: Vec<Reaction>,
+    /// Stat used for bonus scaling. `None` = no personal scaling (e.g. Aino).
+    pub scaling_stat: Option<ScalingStat>,
+    /// Rate per 1 unit of stat.
+    pub rate: f64,
+    /// Maximum bonus value (cap, decimal form).
+    pub max_bonus: f64,
+}
+
+impl MoonsignBenedictionSpec {
+    /// Resolve the spec against a member's stats into a [`MoonsignBenediction`].
+    #[must_use]
+    pub fn resolve(&self, stats: &crate::stats::Stats) -> MoonsignBenediction {
+        let bonus = match self.scaling_stat {
+            Some(ScalingStat::Atk) | Some(ScalingStat::TotalAtk) => {
+                (self.rate * stats.atk).min(self.max_bonus)
+            }
+            Some(ScalingStat::Hp) => (self.rate * stats.hp).min(self.max_bonus),
+            Some(ScalingStat::Def) => (self.rate * stats.def).min(self.max_bonus),
+            Some(ScalingStat::Em) => (self.rate * stats.elemental_mastery).min(self.max_bonus),
+            Some(ScalingStat::CritRate) | None => 0.0,
+        };
+        MoonsignBenediction {
+            base_dmg_bonus: bonus,
+            enabled_reactions: self.enabled_reactions.clone(),
+        }
+    }
+}
+
 /// Moonsign-level dependent talent enhancement.
 ///
 /// Note: only `Serialize` is derived (not `Deserialize`) because `&'static str`

--- a/crates/core/src/team.rs
+++ b/crates/core/src/team.rs
@@ -3,6 +3,9 @@ use serde::{Deserialize, Serialize};
 use crate::buff_types::BuffableStat;
 use crate::enemy::{EnemyDebuffs, collect_enemy_debuffs};
 use crate::error::CalcError;
+use crate::moonsign::{
+    MoonsignBenediction, MoonsignContext, non_moonsign_scaling, resolve_moonsign_context,
+};
 use crate::reaction::{Reaction, ReactionCategory};
 use crate::resonance::{
     ElementalResonance, determine_resonances, resonance_buffs, resonance_conditional_buffs,
@@ -54,6 +57,10 @@ pub struct TeamMember {
     pub is_moonsign: bool,
     /// Whether this character can use Nightsoul's Blessing (夜魂の加護).
     pub can_nightsoul: bool,
+    /// Moonsign Benediction passive spec, if the character has one.
+    /// Used by `resolve_team_stats` to build [`crate::MoonsignContext`].
+    #[serde(default)]
+    pub moonsign_benediction: Option<crate::moonsign::MoonsignBenedictionSpec>,
 }
 
 /// Aggregated attack-type-specific DMG bonuses, flat DMG, and reaction bonuses
@@ -147,7 +154,10 @@ impl DamageContext {
 }
 
 /// Detailed result of team buff resolution.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+///
+/// Only `Serialize` is derived because [`MoonsignContext::talent_enhancements`]
+/// contains `&'static str` fields (Deserialize not supported).
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct TeamResolveResult {
     /// Stats before team buffs.
     pub base_stats: Stats,
@@ -161,6 +171,9 @@ pub struct TeamResolveResult {
     pub damage_context: DamageContext,
     /// Enemy resistance and DEF reduction from team debuffs.
     pub enemy_debuffs: EnemyDebuffs,
+    /// Team-level Moonsign context (level, per-reaction base DMG bonus,
+    /// non-moonsign lunar bonus, talent enhancements).
+    pub moonsign_context: crate::moonsign::MoonsignContext,
 }
 
 /// Returns true if the buff is unconditional (can be applied to StatProfile directly).
@@ -403,6 +416,48 @@ pub fn resolve_team_stats(
     resolve_team_stats_detailed(team, target_index, resonance_activations)
 }
 
+/// Build a [`MoonsignContext`] from a team by resolving each member's
+/// `moonsign_benediction` spec against their own base stats, counting moonsign
+/// members for the level, and computing the non-moonsign lunar bonus cap from
+/// the strongest non-moonsign member.
+fn build_moonsign_context(team: &[TeamMember]) -> MoonsignContext {
+    let moonsign_count = team.iter().filter(|m| m.is_moonsign).count();
+
+    let benedictions: Vec<MoonsignBenediction> = team
+        .iter()
+        .filter_map(|m| {
+            m.moonsign_benediction.as_ref().map(|spec| {
+                let stats = combine_stats(&m.stats).unwrap_or_default();
+                spec.resolve(&stats)
+            })
+        })
+        .collect();
+
+    let non_moonsign_bonus = if moonsign_count >= 2 {
+        team.iter()
+            .filter(|m| !m.is_moonsign)
+            .map(|m| {
+                let stats = combine_stats(&m.stats).unwrap_or_default();
+                let buff = non_moonsign_scaling(m.element);
+                let stat_value = match buff.scaling_stat {
+                    crate::types::ScalingStat::Atk | crate::types::ScalingStat::TotalAtk => {
+                        stats.atk
+                    }
+                    crate::types::ScalingStat::Hp => stats.hp,
+                    crate::types::ScalingStat::Def => stats.def,
+                    crate::types::ScalingStat::Em => stats.elemental_mastery,
+                    crate::types::ScalingStat::CritRate => 0.0,
+                };
+                (buff.rate * stat_value).min(buff.max_bonus)
+            })
+            .fold(0.0_f64, f64::max)
+    } else {
+        0.0
+    };
+
+    resolve_moonsign_context(moonsign_count, &benedictions, non_moonsign_bonus, vec![])
+}
+
 /// Resolves team buffs with detailed breakdown.
 ///
 /// `applied_buffs` contains all buffs including conditional ones.
@@ -430,6 +485,7 @@ pub fn resolve_team_stats_detailed(
 
     let damage_context = DamageContext::from_buffs(&applied_buffs);
     let enemy_debuffs = collect_enemy_debuffs(&applied_buffs);
+    let moonsign_context = build_moonsign_context(team);
 
     Ok(TeamResolveResult {
         base_stats,
@@ -437,6 +493,7 @@ pub fn resolve_team_stats_detailed(
         resonances,
         final_stats,
         damage_context,
+        moonsign_context,
         enemy_debuffs,
     })
 }
@@ -463,6 +520,7 @@ mod tests {
             buffs_provided: vec![],
             is_moonsign: false,
             can_nightsoul: false,
+            moonsign_benediction: None,
         }
     }
 

--- a/crates/core/tests/issue_142_moonsign_context_on_team_result.rs
+++ b/crates/core/tests/issue_142_moonsign_context_on_team_result.rs
@@ -1,0 +1,199 @@
+//! Issue #142: Expose MoonsignContext via TeamResolveResult.
+//!
+//! TeamResolveResult must include a moonsign_context field so consumers can
+//! obtain the per-reaction Base DMG Bonus without passing 0 to LunarInput.
+
+use genshin_calc_core::*;
+
+const EPSILON: f64 = 1e-6;
+
+fn default_profile(base_atk: f64, em: f64) -> StatProfile {
+    StatProfile {
+        base_atk,
+        base_hp: 10000.0,
+        base_def: 500.0,
+        elemental_mastery: em,
+        crit_rate: 0.5,
+        crit_dmg: 1.0,
+        energy_recharge: 1.0,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn test_team_resolve_result_has_moonsign_context_field() {
+    // Single non-moonsign member — moonsign_context should exist and be empty.
+    let member = TeamMember {
+        element: Element::Pyro,
+        weapon_type: WeaponType::Sword,
+        stats: default_profile(2000.0, 0.0),
+        buffs_provided: vec![],
+        is_moonsign: false,
+        can_nightsoul: false,
+        moonsign_benediction: None,
+    };
+    let result = resolve_team_stats(&[member], 0, &[]).unwrap();
+    assert_eq!(result.moonsign_context.level, MoonsignLevel::None);
+    assert!(
+        result
+            .moonsign_context
+            .base_dmg_bonus_by_reaction
+            .is_empty()
+    );
+}
+
+#[test]
+fn test_ineffa_solo_exposes_lunar_ec_base_dmg_bonus() {
+    // Ineffa-like: ATK 2000 → benediction 0.00007 * 2000 = 0.14 for LunarElectroCharged.
+    let member = TeamMember {
+        element: Element::Electro,
+        weapon_type: WeaponType::Catalyst,
+        stats: default_profile(2000.0, 0.0),
+        buffs_provided: vec![],
+        is_moonsign: true,
+        can_nightsoul: false,
+        moonsign_benediction: Some(MoonsignBenedictionSpec {
+            enabled_reactions: vec![Reaction::LunarElectroCharged],
+            scaling_stat: Some(ScalingStat::Atk),
+            rate: 0.00007,
+            max_bonus: 0.14,
+        }),
+    };
+    let result = resolve_team_stats(&[member], 0, &[]).unwrap();
+    assert_eq!(result.moonsign_context.level, MoonsignLevel::NascentGleam);
+    let bonus = result
+        .moonsign_context
+        .base_dmg_bonus_for(Reaction::LunarElectroCharged);
+    assert!((bonus - 0.14).abs() < EPSILON);
+}
+
+#[test]
+fn test_two_moonsign_team_ascendant_gleam() {
+    // Ineffa (+0.14 LunarEC) + Columbina (+0.07 LunarEC/Bloom/Crystallize).
+    // Total LunarEC = 0.21.
+    let ineffa = TeamMember {
+        element: Element::Electro,
+        weapon_type: WeaponType::Catalyst,
+        stats: default_profile(2000.0, 0.0),
+        buffs_provided: vec![],
+        is_moonsign: true,
+        can_nightsoul: false,
+        moonsign_benediction: Some(MoonsignBenedictionSpec {
+            enabled_reactions: vec![Reaction::LunarElectroCharged],
+            scaling_stat: Some(ScalingStat::Atk),
+            rate: 0.00007,
+            max_bonus: 0.14,
+        }),
+    };
+    let columbina = TeamMember {
+        element: Element::Hydro,
+        weapon_type: WeaponType::Catalyst,
+        stats: StatProfile {
+            base_hp: 35000.0,
+            ..default_profile(1000.0, 0.0)
+        },
+        buffs_provided: vec![],
+        is_moonsign: true,
+        can_nightsoul: false,
+        moonsign_benediction: Some(MoonsignBenedictionSpec {
+            enabled_reactions: vec![
+                Reaction::LunarElectroCharged,
+                Reaction::LunarBloom,
+                Reaction::LunarCrystallize,
+            ],
+            scaling_stat: Some(ScalingStat::Hp),
+            rate: 0.000002,
+            max_bonus: 0.07,
+        }),
+    };
+    let result = resolve_team_stats(&[ineffa, columbina], 0, &[]).unwrap();
+    assert_eq!(result.moonsign_context.level, MoonsignLevel::AscendantGleam);
+    let ec = result
+        .moonsign_context
+        .base_dmg_bonus_for(Reaction::LunarElectroCharged);
+    assert!((ec - 0.21).abs() < EPSILON, "LunarEC bonus: {ec}");
+    let bloom = result
+        .moonsign_context
+        .base_dmg_bonus_for(Reaction::LunarBloom);
+    assert!((bloom - 0.07).abs() < EPSILON, "LunarBloom bonus: {bloom}");
+}
+
+#[test]
+fn test_non_moonsign_lunar_bonus_computed_for_non_moonsign_members() {
+    // non_moonsign_lunar_bonus is only active at AscendantGleam (2+ moonsign).
+    // Ineffa + Columbina (both moonsign) + Pyro non-moonsign with 2000 ATK.
+    // Expected: 0.00009 * 2000 = 0.18 (cap 0.36).
+    let ineffa = TeamMember {
+        element: Element::Electro,
+        weapon_type: WeaponType::Catalyst,
+        stats: default_profile(2000.0, 0.0),
+        buffs_provided: vec![],
+        is_moonsign: true,
+        can_nightsoul: false,
+        moonsign_benediction: Some(MoonsignBenedictionSpec {
+            enabled_reactions: vec![Reaction::LunarElectroCharged],
+            scaling_stat: Some(ScalingStat::Atk),
+            rate: 0.00007,
+            max_bonus: 0.14,
+        }),
+    };
+    let columbina = TeamMember {
+        element: Element::Hydro,
+        weapon_type: WeaponType::Catalyst,
+        stats: default_profile(1000.0, 0.0),
+        buffs_provided: vec![],
+        is_moonsign: true,
+        can_nightsoul: false,
+        moonsign_benediction: Some(MoonsignBenedictionSpec {
+            enabled_reactions: vec![Reaction::LunarBloom],
+            scaling_stat: Some(ScalingStat::Hp),
+            rate: 0.000002,
+            max_bonus: 0.07,
+        }),
+    };
+    let pyro_dps = TeamMember {
+        element: Element::Pyro,
+        weapon_type: WeaponType::Sword,
+        stats: default_profile(2000.0, 0.0),
+        buffs_provided: vec![],
+        is_moonsign: false,
+        can_nightsoul: false,
+        moonsign_benediction: None,
+    };
+    let result = resolve_team_stats(&[ineffa, columbina, pyro_dps], 0, &[]).unwrap();
+    assert!(
+        (result.moonsign_context.non_moonsign_lunar_bonus - 0.18).abs() < EPSILON,
+        "got {}",
+        result.moonsign_context.non_moonsign_lunar_bonus
+    );
+}
+
+#[test]
+fn test_non_moonsign_lunar_bonus_zero_at_nascent_gleam() {
+    // At NascentGleam (1 moonsign), non_moonsign_lunar_bonus must stay 0.
+    let ineffa = TeamMember {
+        element: Element::Electro,
+        weapon_type: WeaponType::Catalyst,
+        stats: default_profile(2000.0, 0.0),
+        buffs_provided: vec![],
+        is_moonsign: true,
+        can_nightsoul: false,
+        moonsign_benediction: Some(MoonsignBenedictionSpec {
+            enabled_reactions: vec![Reaction::LunarElectroCharged],
+            scaling_stat: Some(ScalingStat::Atk),
+            rate: 0.00007,
+            max_bonus: 0.14,
+        }),
+    };
+    let pyro_dps = TeamMember {
+        element: Element::Pyro,
+        weapon_type: WeaponType::Sword,
+        stats: default_profile(2000.0, 0.0),
+        buffs_provided: vec![],
+        is_moonsign: false,
+        can_nightsoul: false,
+        moonsign_benediction: None,
+    };
+    let result = resolve_team_stats(&[ineffa, pyro_dps], 0, &[]).unwrap();
+    assert!((result.moonsign_context.non_moonsign_lunar_bonus - 0.0).abs() < EPSILON);
+}

--- a/crates/data/src/team_builder.rs
+++ b/crates/data/src/team_builder.rs
@@ -224,6 +224,15 @@ impl TeamMemberBuilder {
             buffs_provided: buffs,
             is_moonsign: is_moonsign_character(self.character.id),
             can_nightsoul: is_nightsoul_character(self.character.id),
+            moonsign_benediction: crate::moonsign_chars::find_moonsign_benediction(
+                self.character.id,
+            )
+            .map(|def| genshin_calc_core::MoonsignBenedictionSpec {
+                enabled_reactions: def.enabled_reactions.to_vec(),
+                scaling_stat: def.scaling_stat,
+                rate: def.rate,
+                max_bonus: def.max_bonus,
+            }),
         }
     }
 

--- a/crates/data/tests/issue_70_geo_dendro_passives.rs
+++ b/crates/data/tests/issue_70_geo_dendro_passives.rs
@@ -27,6 +27,7 @@ fn dummy_member(element: Element, base_def: f64) -> TeamMember {
         buffs_provided: vec![],
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     }
 }
 

--- a/crates/data/tests/issue_71_other_passives.rs
+++ b/crates/data/tests/issue_71_other_passives.rs
@@ -26,6 +26,7 @@ fn dummy_member(element: Element, base_def: f64) -> TeamMember {
         buffs_provided: vec![],
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     }
 }
 

--- a/crates/data/tests/issue_72_elemental_crit_dmg.rs
+++ b/crates/data/tests/issue_72_elemental_crit_dmg.rs
@@ -27,6 +27,7 @@ fn dummy_member(element: Element) -> TeamMember {
         buffs_provided: vec![],
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     }
 }
 

--- a/crates/data/tests/issue_73_cleanup.rs
+++ b/crates/data/tests/issue_73_cleanup.rs
@@ -29,6 +29,7 @@ fn dummy_member(element: Element) -> TeamMember {
         buffs_provided: vec![],
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     }
 }
 

--- a/crates/data/tests/issue_74_collei_c6.rs
+++ b/crates/data/tests/issue_74_collei_c6.rs
@@ -26,6 +26,7 @@ fn dummy_member(element: Element) -> TeamMember {
         buffs_provided: vec![],
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     }
 }
 

--- a/crates/data/tests/meta_team_edge_cases.rs
+++ b/crates/data/tests/meta_team_edge_cases.rs
@@ -61,6 +61,7 @@ fn edge_res_shred_stacking() {
         buffs_provided: vec![],
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     };
 
     let team = [dps, kazuha, zhongli];
@@ -377,6 +378,7 @@ fn edge_furina_fanfare_scaling() {
         buffs_provided: vec![],
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     };
 
     let team_no_stacks = [furina, dps.clone()];
@@ -745,6 +747,7 @@ fn edge_bennett_c6_pyro_dmg() {
         buffs_provided: vec![],
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     };
 
     let team = [bennett_c6, dps];

--- a/crates/data/tests/meta_team_verification.rs
+++ b/crates/data/tests/meta_team_verification.rs
@@ -1354,6 +1354,7 @@ fn cross_team_bennett_buff_consistency() {
         buffs_provided: vec![],
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     };
 
     let dps2 = TeamMember {
@@ -1371,6 +1372,7 @@ fn cross_team_bennett_buff_consistency() {
         buffs_provided: vec![],
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     };
 
     let team1 = [bennett.clone(), dps1];

--- a/crates/data/tests/team_integration.rs
+++ b/crates/data/tests/team_integration.rs
@@ -32,6 +32,7 @@ fn test_bennett_kazuha_team_damage() {
         buffs_provided: vec![],
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     };
 
     let team = [bennett, dps];

--- a/crates/good/tests/evaluate_talent_buffs_integration.rs
+++ b/crates/good/tests/evaluate_talent_buffs_integration.rs
@@ -74,6 +74,7 @@ fn test_pipeline_build_member_stats_to_resolve_team() {
         buffs_provided: buffs,
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     };
 
     let result = genshin_calc_core::resolve_team_stats(&[member], 0, &[]);

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -741,6 +741,7 @@ mod tests {
             buffs_provided: vec![],
             is_moonsign: false,
             can_nightsoul: false,
+            moonsign_benediction: None,
         };
         let result = resolve_team_stats(&[dps], 0, &[]).unwrap();
         assert!(result.final_stats.atk > 0.0);

--- a/crates/wasm/ts/types.ts
+++ b/crates/wasm/ts/types.ts
@@ -166,6 +166,13 @@ export interface ResolvedBuff {
   target: BuffTarget;
 }
 
+export interface MoonsignBenedictionSpec {
+  enabled_reactions: Reaction[];
+  scaling_stat: ScalingStat | null;
+  rate: number;
+  max_bonus: number;
+}
+
 export interface TeamMember {
   element: Element;
   weapon_type: WeaponType;
@@ -173,6 +180,24 @@ export interface TeamMember {
   buffs_provided: ResolvedBuff[];
   is_moonsign: boolean;
   can_nightsoul: boolean;
+  moonsign_benediction?: MoonsignBenedictionSpec | null;
+}
+
+export type MoonsignLevel = "None" | "NascentGleam" | "AscendantGleam";
+
+/**
+ * Team-level Moonsign context, exposed via `resolve_team_stats` / `TeamResolveResult`.
+ * Use `base_dmg_bonus_by_reaction` to obtain the per-reaction Base DMG Bonus
+ * that must be passed to `LunarInput.base_dmg_bonus` / `DirectLunarInput.base_dmg_bonus`.
+ * Use `non_moonsign_lunar_bonus` as `reaction_bonus` for non-moonsign members at AscendantGleam.
+ */
+export interface MoonsignContext {
+  level: MoonsignLevel;
+  base_dmg_bonus_by_reaction: Array<[Reaction, number]>;
+  non_moonsign_lunar_bonus: number;
+  // talent_enhancements contains `&'static str` fields (Rust-only); serialized
+  // form is available but not deserializable.
+  talent_enhancements: unknown[];
 }
 
 // === GOOD Import Types ===
@@ -379,4 +404,20 @@ export interface WeaponData {
 export interface ArtifactSetData {
   id: string;
   name: string;
+}
+
+
+/**
+ * Return type of `resolve_team_stats`. Includes the team-level Moonsign context
+ * (Issue #142) so JS/TS consumers can obtain `base_dmg_bonus_by_reaction` to
+ * feed into `LunarInput.base_dmg_bonus` / `DirectLunarInput.base_dmg_bonus`.
+ */
+export interface TeamResolveResult {
+  base_stats: Stats;
+  applied_buffs: ResolvedBuff[];
+  resonances: string[];
+  final_stats: Stats;
+  damage_context: unknown;
+  enemy_debuffs: unknown;
+  moonsign_context: MoonsignContext;
 }


### PR DESCRIPTION
## Summary
- Add `moonsign_benediction` spec to `TeamMember` and surface a full `MoonsignContext` on `TeamResolveResult` so JS/TS consumers can obtain the per-reaction Moonsign Benediction Base DMG Bonus without guessing or passing `0`.
- `build_moonsign_context` resolves each member's spec against their stats, derives moonsign level from count, and computes the strongest non-moonsign lunar bonus (active at AscendantGleam only).
- Drop `Deserialize` from `TeamResolveResult` (no active Rust deserialize consumers; WASM binding is serialize-only) so the embedded `&'static str`-bearing `MoonsignContext` compiles cleanly.

## Test plan
- [x] New integration tests `crates/core/tests/issue_142_moonsign_context_on_team_result.rs`:
  - `test_team_resolve_result_has_moonsign_context_field` — context defaults for a non-moonsign-only team
  - `test_ineffa_solo_exposes_lunar_ec_base_dmg_bonus` — single-member benediction derived from ATK
  - `test_two_moonsign_team_ascendant_gleam` — Ineffa + Columbina aggregation across LunarEC/LunarBloom
  - `test_non_moonsign_lunar_bonus_computed_for_non_moonsign_members` — 0.18 at AscendantGleam
  - `test_non_moonsign_lunar_bonus_zero_at_nascent_gleam` — gated at 2+ moonsign
- [x] `cargo test --workspace --all-targets` green
- [x] `cargo clippy -p genshin-calc-core --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

## Related
- Closes #142
- Unblocks #143 (pipeline wiring of `MoonsignTalentEnhancement`) and #144 (dedupe Flins A1)