### PR TITLE
feat(core+data): wire MoonsignTalentEnhancement into pipeline (#143)

### DIFF
--- a/crates/core/src/enemy.rs
+++ b/crates/core/src/enemy.rs
@@ -745,6 +745,7 @@ mod tests {
             is_moonsign: false,
             can_nightsoul: false,
             moonsign_benediction: None,
+            moonsign_talent_enhancements: &[],
         };
 
         let support = TeamMember {
@@ -788,6 +789,7 @@ mod tests {
             is_moonsign: false,
             can_nightsoul: false,
             moonsign_benediction: None,
+            moonsign_talent_enhancements: &[],
         };
 
         let team = vec![dps, support];

--- a/crates/core/src/moonsign.rs
+++ b/crates/core/src/moonsign.rs
@@ -285,7 +285,9 @@ pub fn apply_moonsign_enhancements(
                 }
             }
             MoonsignTalentEffect::StatBuff { .. } => {
-                // StatBuff is applied at the stat-profile level, not directly to LunarInput
+                // StatBuff is routed through `resolve_team_stats` into
+                // `applied_buffs` / `final_stats` (Issue #143), not through
+                // this per-lunar-input helper.
             }
         }
     }

--- a/crates/core/src/team.rs
+++ b/crates/core/src/team.rs
@@ -4,7 +4,8 @@ use crate::buff_types::BuffableStat;
 use crate::enemy::{EnemyDebuffs, collect_enemy_debuffs};
 use crate::error::CalcError;
 use crate::moonsign::{
-    MoonsignBenediction, MoonsignContext, non_moonsign_scaling, resolve_moonsign_context,
+    MoonsignBenediction, MoonsignContext, MoonsignLevel, MoonsignTalentEffect,
+    MoonsignTalentEnhancement, non_moonsign_scaling, resolve_moonsign_context,
 };
 use crate::reaction::{Reaction, ReactionCategory};
 use crate::resonance::{
@@ -61,6 +62,22 @@ pub struct TeamMember {
     /// Used by `resolve_team_stats` to build [`crate::MoonsignContext`].
     #[serde(default)]
     pub moonsign_benediction: Option<crate::moonsign::MoonsignBenedictionSpec>,
+    /// All Moonsign talent enhancements this character may contribute, including
+    /// every `required_level`. `resolve_team_stats` filters by the resolved team
+    /// level and routes `StatBuff` / `ReactionDmgBonus` effects into
+    /// `applied_buffs` / `damage_context` automatically. `GrantReactionCrit`
+    /// effects remain in `moonsign_context.talent_enhancements` and must be
+    /// applied at the lunar pipeline via `apply_moonsign_enhancements`.
+    #[serde(
+        skip_serializing,
+        skip_deserializing,
+        default = "empty_moonsign_enhancements"
+    )]
+    pub moonsign_talent_enhancements: &'static [crate::moonsign::MoonsignTalentEnhancement],
+}
+
+fn empty_moonsign_enhancements() -> &'static [crate::moonsign::MoonsignTalentEnhancement] {
+    &[]
 }
 
 /// Aggregated attack-type-specific DMG bonuses, flat DMG, and reaction bonuses
@@ -455,7 +472,113 @@ fn build_moonsign_context(team: &[TeamMember]) -> MoonsignContext {
         0.0
     };
 
-    resolve_moonsign_context(moonsign_count, &benedictions, non_moonsign_bonus, vec![])
+    let active_enhancements = collect_active_enhancements(team, moonsign_count);
+    resolve_moonsign_context(
+        moonsign_count,
+        &benedictions,
+        non_moonsign_bonus,
+        active_enhancements,
+    )
+}
+
+/// Filter each member's `moonsign_talent_enhancements` by the resolved team
+/// moonsign level and return the flat list of enhancements that are active.
+fn collect_active_enhancements(
+    team: &[TeamMember],
+    moonsign_count: usize,
+) -> Vec<MoonsignTalentEnhancement> {
+    let level = crate::moonsign::determine_moonsign_level(moonsign_count);
+    team.iter()
+        .flat_map(|m| m.moonsign_talent_enhancements.iter())
+        .filter(|e| enhancement_is_active(e.required_level, level))
+        .cloned()
+        .collect()
+}
+
+fn enhancement_is_active(required: MoonsignLevel, current: MoonsignLevel) -> bool {
+    matches!(
+        (required, current),
+        (MoonsignLevel::None, _)
+            | (
+                MoonsignLevel::NascentGleam,
+                MoonsignLevel::NascentGleam | MoonsignLevel::AscendantGleam,
+            )
+            | (MoonsignLevel::AscendantGleam, MoonsignLevel::AscendantGleam)
+    )
+}
+
+/// Convert Moonsign talent enhancements with `StatBuff` / `ReactionDmgBonus`
+/// effects into `ResolvedBuff`s so they flow through the normal team buff
+/// resolution (applied_buffs + final_stats + damage_context).
+///
+/// Each enhancement is attributed to a specific member via
+/// `moonsign_talent_enhancements`, which determines the buff `target` scope
+/// (OnlySelf / Team / TeamExcludeSelf) — the buff is only included in
+/// `applied_buffs` for the target member if the scope matches.
+fn enhancement_buffs_for_target(
+    team: &[TeamMember],
+    target_index: usize,
+    level: MoonsignLevel,
+) -> Vec<ResolvedBuff> {
+    let mut out = Vec::new();
+    for (idx, member) in team.iter().enumerate() {
+        for ench in member.moonsign_talent_enhancements {
+            if !enhancement_is_active(ench.required_level, level) {
+                continue;
+            }
+            match &ench.effect {
+                MoonsignTalentEffect::StatBuff {
+                    stat,
+                    value,
+                    target,
+                } => {
+                    if !target_receives(*target, idx, target_index) {
+                        continue;
+                    }
+                    out.push(ResolvedBuff {
+                        source: format!("Moonsign: {} — {}", ench.character_name, ench.description),
+                        stat: *stat,
+                        value: *value,
+                        target: *target,
+                        origin: Some(format!(
+                            "moonsign:{}:{:?}",
+                            ench.character_name, ench.required_level
+                        )),
+                    });
+                }
+                MoonsignTalentEffect::ReactionDmgBonus { reaction, bonus } => {
+                    // ReactionDmgBonus enhancements are treated as Team by
+                    // default because their game semantics typically benefit
+                    // every reaction triggerer. Future extension: add explicit
+                    // target field to the variant if any effect is self-only.
+                    out.push(ResolvedBuff {
+                        source: format!("Moonsign: {} — {}", ench.character_name, ench.description),
+                        stat: BuffableStat::ReactionDmgBonus(*reaction),
+                        value: *bonus,
+                        target: BuffTarget::Team,
+                        origin: Some(format!(
+                            "moonsign:{}:{:?}",
+                            ench.character_name, ench.required_level
+                        )),
+                    });
+                }
+                MoonsignTalentEffect::GrantReactionCrit { .. } => {
+                    // Intentionally left out — crit grants apply at the lunar
+                    // pipeline via apply_moonsign_enhancements and have no
+                    // BuffableStat equivalent.
+                }
+            }
+        }
+    }
+    out
+}
+
+fn target_receives(target: BuffTarget, provider_idx: usize, target_idx: usize) -> bool {
+    match target {
+        BuffTarget::Team => true,
+        BuffTarget::OnlySelf => provider_idx == target_idx,
+        BuffTarget::TeamExcludeSelf => provider_idx != target_idx,
+    }
 }
 
 /// Resolves team buffs with detailed breakdown.
@@ -476,7 +599,15 @@ pub fn resolve_team_stats_detailed(
     let base_profile = &team[target_index].stats;
     let base_stats = combine_stats(base_profile)?;
 
-    let applied_buffs = collect_buffs(team, target_index, resonance_activations);
+    let moonsign_count = team.iter().filter(|m| m.is_moonsign).count();
+    let moonsign_level = crate::moonsign::determine_moonsign_level(moonsign_count);
+
+    let mut applied_buffs = collect_buffs(team, target_index, resonance_activations);
+    applied_buffs.extend(enhancement_buffs_for_target(
+        team,
+        target_index,
+        moonsign_level,
+    ));
     let buffed_profile = apply_buffs_to_profile(base_profile, &applied_buffs);
     let final_stats = combine_stats(&buffed_profile)?;
 
@@ -521,6 +652,7 @@ mod tests {
             is_moonsign: false,
             can_nightsoul: false,
             moonsign_benediction: None,
+            moonsign_talent_enhancements: &[],
         }
     }
 

--- a/crates/core/tests/issue_142_moonsign_context_on_team_result.rs
+++ b/crates/core/tests/issue_142_moonsign_context_on_team_result.rs
@@ -31,6 +31,7 @@ fn test_team_resolve_result_has_moonsign_context_field() {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     };
     let result = resolve_team_stats(&[member], 0, &[]).unwrap();
     assert_eq!(result.moonsign_context.level, MoonsignLevel::None);
@@ -58,6 +59,7 @@ fn test_ineffa_solo_exposes_lunar_ec_base_dmg_bonus() {
             rate: 0.00007,
             max_bonus: 0.14,
         }),
+        moonsign_talent_enhancements: &[],
     };
     let result = resolve_team_stats(&[member], 0, &[]).unwrap();
     assert_eq!(result.moonsign_context.level, MoonsignLevel::NascentGleam);
@@ -84,6 +86,7 @@ fn test_two_moonsign_team_ascendant_gleam() {
             rate: 0.00007,
             max_bonus: 0.14,
         }),
+        moonsign_talent_enhancements: &[],
     };
     let columbina = TeamMember {
         element: Element::Hydro,
@@ -105,6 +108,7 @@ fn test_two_moonsign_team_ascendant_gleam() {
             rate: 0.000002,
             max_bonus: 0.07,
         }),
+        moonsign_talent_enhancements: &[],
     };
     let result = resolve_team_stats(&[ineffa, columbina], 0, &[]).unwrap();
     assert_eq!(result.moonsign_context.level, MoonsignLevel::AscendantGleam);
@@ -136,6 +140,7 @@ fn test_non_moonsign_lunar_bonus_computed_for_non_moonsign_members() {
             rate: 0.00007,
             max_bonus: 0.14,
         }),
+        moonsign_talent_enhancements: &[],
     };
     let columbina = TeamMember {
         element: Element::Hydro,
@@ -150,6 +155,7 @@ fn test_non_moonsign_lunar_bonus_computed_for_non_moonsign_members() {
             rate: 0.000002,
             max_bonus: 0.07,
         }),
+        moonsign_talent_enhancements: &[],
     };
     let pyro_dps = TeamMember {
         element: Element::Pyro,
@@ -159,6 +165,7 @@ fn test_non_moonsign_lunar_bonus_computed_for_non_moonsign_members() {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     };
     let result = resolve_team_stats(&[ineffa, columbina, pyro_dps], 0, &[]).unwrap();
     assert!(
@@ -184,6 +191,7 @@ fn test_non_moonsign_lunar_bonus_zero_at_nascent_gleam() {
             rate: 0.00007,
             max_bonus: 0.14,
         }),
+        moonsign_talent_enhancements: &[],
     };
     let pyro_dps = TeamMember {
         element: Element::Pyro,
@@ -193,6 +201,7 @@ fn test_non_moonsign_lunar_bonus_zero_at_nascent_gleam() {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     };
     let result = resolve_team_stats(&[ineffa, pyro_dps], 0, &[]).unwrap();
     assert!((result.moonsign_context.non_moonsign_lunar_bonus - 0.0).abs() < EPSILON);

--- a/crates/core/tests/issue_143_moonsign_enhancement_pipeline.rs
+++ b/crates/core/tests/issue_143_moonsign_enhancement_pipeline.rs
@@ -1,0 +1,197 @@
+//! Issue #143: MoonsignTalentEnhancement must flow through the team resolution
+//! pipeline automatically.
+//!
+//! - `StatBuff` must surface in `applied_buffs` and (for unconditional stat kinds)
+//!   reflect in `final_stats`.
+//! - `ReactionDmgBonus` must surface in `damage_context.reaction_dmg_bonuses`.
+//! - `GrantReactionCrit` remains in `moonsign_context.talent_enhancements` for
+//!   consumers to apply via `apply_moonsign_enhancements`.
+
+use genshin_calc_core::*;
+
+const EPSILON: f64 = 1e-6;
+
+fn base_profile(atk: f64, em: f64) -> StatProfile {
+    StatProfile {
+        base_atk: atk,
+        base_hp: 10000.0,
+        base_def: 500.0,
+        elemental_mastery: em,
+        crit_rate: 0.5,
+        crit_dmg: 1.0,
+        energy_recharge: 1.0,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn test_nefer_a1_em_stat_buff_applied_to_target_at_ascendant_gleam() {
+    // Nefer A1 at Ascendant grants EM +100 to self. Set up a 2-moonsign team
+    // (Ascendant level) and resolve targeting Nefer.
+    let nefer_enhancement: &'static [MoonsignTalentEnhancement] =
+        Box::leak(Box::new([MoonsignTalentEnhancement {
+            character_name: "Nefer",
+            required_level: MoonsignLevel::AscendantGleam,
+            description: "Nefer A1 EM +100 at Ascendant Gleam",
+            effect: MoonsignTalentEffect::StatBuff {
+                stat: BuffableStat::ElementalMastery,
+                value: 100.0,
+                target: BuffTarget::OnlySelf,
+            },
+        }]));
+    let nefer = TeamMember {
+        element: Element::Dendro,
+        weapon_type: WeaponType::Catalyst,
+        stats: base_profile(1500.0, 500.0),
+        buffs_provided: vec![],
+        is_moonsign: true,
+        can_nightsoul: false,
+        moonsign_benediction: Some(MoonsignBenedictionSpec {
+            enabled_reactions: vec![Reaction::LunarBloom],
+            scaling_stat: Some(ScalingStat::Em),
+            rate: 0.000175,
+            max_bonus: 0.14,
+        }),
+        moonsign_talent_enhancements: nefer_enhancement,
+    };
+    let columbina = TeamMember {
+        element: Element::Hydro,
+        weapon_type: WeaponType::Catalyst,
+        stats: base_profile(1000.0, 0.0),
+        buffs_provided: vec![],
+        is_moonsign: true,
+        can_nightsoul: false,
+        moonsign_benediction: Some(MoonsignBenedictionSpec {
+            enabled_reactions: vec![
+                Reaction::LunarElectroCharged,
+                Reaction::LunarBloom,
+                Reaction::LunarCrystallize,
+            ],
+            scaling_stat: Some(ScalingStat::Hp),
+            rate: 0.000002,
+            max_bonus: 0.07,
+        }),
+        moonsign_talent_enhancements: &[],
+    };
+
+    let result = resolve_team_stats(&[nefer, columbina], 0, &[]).unwrap();
+
+    // applied_buffs must contain the EM +100 buff
+    let em_buff = result.applied_buffs.iter().find(|b| {
+        matches!(b.stat, BuffableStat::ElementalMastery) && (b.value - 100.0).abs() < EPSILON
+    });
+    assert!(
+        em_buff.is_some(),
+        "expected EM +100 in applied_buffs, got: {:?}",
+        result
+            .applied_buffs
+            .iter()
+            .map(|b| (&b.source, &b.stat, b.value))
+            .collect::<Vec<_>>()
+    );
+
+    // final_stats.elemental_mastery reflects the +100 on top of base 500
+    assert!(
+        (result.final_stats.elemental_mastery - 600.0).abs() < EPSILON,
+        "got {}",
+        result.final_stats.elemental_mastery
+    );
+}
+
+#[test]
+fn test_reaction_dmg_bonus_enhancement_reaches_damage_context() {
+    // Synthetic Moonsign char granting LunarBloom +20% at Ascendant Gleam (self).
+    let ench: &'static [MoonsignTalentEnhancement] =
+        Box::leak(Box::new([MoonsignTalentEnhancement {
+            character_name: "TestBloomBoost",
+            required_level: MoonsignLevel::AscendantGleam,
+            description: "LunarBloom +20%",
+            effect: MoonsignTalentEffect::ReactionDmgBonus {
+                reaction: Reaction::LunarBloom,
+                bonus: 0.20,
+            },
+        }]));
+    let bloom_char = TeamMember {
+        element: Element::Dendro,
+        weapon_type: WeaponType::Catalyst,
+        stats: base_profile(1500.0, 500.0),
+        buffs_provided: vec![],
+        is_moonsign: true,
+        can_nightsoul: false,
+        moonsign_benediction: Some(MoonsignBenedictionSpec {
+            enabled_reactions: vec![Reaction::LunarBloom],
+            scaling_stat: Some(ScalingStat::Em),
+            rate: 0.000175,
+            max_bonus: 0.14,
+        }),
+        moonsign_talent_enhancements: ench,
+    };
+    let partner = TeamMember {
+        element: Element::Hydro,
+        weapon_type: WeaponType::Catalyst,
+        stats: base_profile(1000.0, 0.0),
+        buffs_provided: vec![],
+        is_moonsign: true,
+        can_nightsoul: false,
+        moonsign_benediction: Some(MoonsignBenedictionSpec {
+            enabled_reactions: vec![Reaction::LunarBloom],
+            scaling_stat: Some(ScalingStat::Hp),
+            rate: 0.000002,
+            max_bonus: 0.07,
+        }),
+        moonsign_talent_enhancements: &[],
+    };
+
+    let result = resolve_team_stats(&[bloom_char, partner], 0, &[]).unwrap();
+
+    let bloom_bonus = result
+        .damage_context
+        .reaction_bonus_for(Reaction::LunarBloom);
+    assert!(
+        (bloom_bonus - 0.20).abs() < EPSILON,
+        "expected LunarBloom +20% in damage_context, got {}",
+        bloom_bonus
+    );
+    // Non-matching reaction must not be affected
+    let ec_bonus = result
+        .damage_context
+        .reaction_bonus_for(Reaction::LunarElectroCharged);
+    assert!(
+        (ec_bonus - 0.0).abs() < EPSILON,
+        "LunarEC must not receive LunarBloom enhancement, got {}",
+        ec_bonus
+    );
+}
+
+#[test]
+fn test_nascent_enhancement_not_applied_at_level_none() {
+    // Enhancement required_level = NascentGleam. With 0 moonsign members the
+    // team level is None, so the enhancement must NOT be applied.
+    let ench: &'static [MoonsignTalentEnhancement] =
+        Box::leak(Box::new([MoonsignTalentEnhancement {
+            character_name: "TestNone",
+            required_level: MoonsignLevel::NascentGleam,
+            description: "dummy",
+            effect: MoonsignTalentEffect::StatBuff {
+                stat: BuffableStat::ElementalMastery,
+                value: 100.0,
+                target: BuffTarget::OnlySelf,
+            },
+        }]));
+    let non_moonsign = TeamMember {
+        element: Element::Pyro,
+        weapon_type: WeaponType::Sword,
+        stats: base_profile(1500.0, 0.0),
+        buffs_provided: vec![],
+        is_moonsign: false,
+        can_nightsoul: false,
+        moonsign_benediction: None,
+        moonsign_talent_enhancements: ench,
+    };
+    let result = resolve_team_stats(&[non_moonsign], 0, &[]).unwrap();
+    // No EM buff from inactive enhancement
+    let has_em_buff = result.applied_buffs.iter().any(|b| {
+        matches!(b.stat, BuffableStat::ElementalMastery) && (b.value - 100.0).abs() < EPSILON
+    });
+    assert!(!has_em_buff, "inactive enhancement must not produce buffs");
+}

--- a/crates/data/src/moonsign_chars.rs
+++ b/crates/data/src/moonsign_chars.rs
@@ -177,26 +177,103 @@ pub const NEFER_TALENT_ENHANCEMENTS: &[MoonsignTalentEnhancement] = &[MoonsignTa
 }];
 
 /// Talent enhancements for Aino.
-/// C6 reaction DMG bonus varies by Moonsign level: Lv1=+15%, Lv2=+35%.
+/// C6: For 15s after Burst, DMG from nearby active characters' Electro-Charged,
+/// Bloom, Lunar-Charged, Lunar-Bloom, and Lunar-Crystallize reactions is
+/// increased. Nascent Gleam grants +15%, Ascendant Gleam adds another +20%
+/// (total +35%).
+///
+/// Implementation note: each `ReactionDmgBonus` variant targets a single
+/// reaction, so the 5 affected reactions expand into 5 entries per level.
 pub const AINO_TALENT_ENHANCEMENTS: &[MoonsignTalentEnhancement] = &[
+    // Nascent Gleam: +15% to each of the 5 reactions.
     MoonsignTalentEnhancement {
         character_name: "Aino",
         required_level: MoonsignLevel::NascentGleam,
-        description: desc!("C6: At Nascent Gleam+, reaction DMG +15% for 15s after Burst"),
-        effect: MoonsignTalentEffect::StatBuff {
-            stat: BuffableStat::TransformativeBonus,
-            value: 0.15,
-            target: BuffTarget::Team,
+        description: desc!("C6: Electro-Charged +15% for 15s after Burst (Nascent Gleam+)"),
+        effect: MoonsignTalentEffect::ReactionDmgBonus {
+            reaction: Reaction::ElectroCharged,
+            bonus: 0.15,
+        },
+    },
+    MoonsignTalentEnhancement {
+        character_name: "Aino",
+        required_level: MoonsignLevel::NascentGleam,
+        description: desc!("C6: Bloom +15% for 15s after Burst (Nascent Gleam+)"),
+        effect: MoonsignTalentEffect::ReactionDmgBonus {
+            reaction: Reaction::Bloom,
+            bonus: 0.15,
+        },
+    },
+    MoonsignTalentEnhancement {
+        character_name: "Aino",
+        required_level: MoonsignLevel::NascentGleam,
+        description: desc!("C6: Lunar-Charged +15% for 15s after Burst (Nascent Gleam+)"),
+        effect: MoonsignTalentEffect::ReactionDmgBonus {
+            reaction: Reaction::LunarElectroCharged,
+            bonus: 0.15,
+        },
+    },
+    MoonsignTalentEnhancement {
+        character_name: "Aino",
+        required_level: MoonsignLevel::NascentGleam,
+        description: desc!("C6: Lunar-Bloom +15% for 15s after Burst (Nascent Gleam+)"),
+        effect: MoonsignTalentEffect::ReactionDmgBonus {
+            reaction: Reaction::LunarBloom,
+            bonus: 0.15,
+        },
+    },
+    MoonsignTalentEnhancement {
+        character_name: "Aino",
+        required_level: MoonsignLevel::NascentGleam,
+        description: desc!("C6: Lunar-Crystallize +15% for 15s after Burst (Nascent Gleam+)"),
+        effect: MoonsignTalentEffect::ReactionDmgBonus {
+            reaction: Reaction::LunarCrystallize,
+            bonus: 0.15,
+        },
+    },
+    // Ascendant Gleam: additional +20% on each of the same 5 reactions.
+    MoonsignTalentEnhancement {
+        character_name: "Aino",
+        required_level: MoonsignLevel::AscendantGleam,
+        description: desc!("C6: Electro-Charged additional +20% at Ascendant Gleam"),
+        effect: MoonsignTalentEffect::ReactionDmgBonus {
+            reaction: Reaction::ElectroCharged,
+            bonus: 0.20,
         },
     },
     MoonsignTalentEnhancement {
         character_name: "Aino",
         required_level: MoonsignLevel::AscendantGleam,
-        description: desc!(
-            "C6: At Ascendant Gleam, reaction DMG bonus increases by +20% (total +35%)"
-        ),
+        description: desc!("C6: Bloom additional +20% at Ascendant Gleam"),
+        effect: MoonsignTalentEffect::ReactionDmgBonus {
+            reaction: Reaction::Bloom,
+            bonus: 0.20,
+        },
+    },
+    MoonsignTalentEnhancement {
+        character_name: "Aino",
+        required_level: MoonsignLevel::AscendantGleam,
+        description: desc!("C6: Lunar-Charged additional +20% at Ascendant Gleam"),
         effect: MoonsignTalentEffect::ReactionDmgBonus {
             reaction: Reaction::LunarElectroCharged,
+            bonus: 0.20,
+        },
+    },
+    MoonsignTalentEnhancement {
+        character_name: "Aino",
+        required_level: MoonsignLevel::AscendantGleam,
+        description: desc!("C6: Lunar-Bloom additional +20% at Ascendant Gleam"),
+        effect: MoonsignTalentEffect::ReactionDmgBonus {
+            reaction: Reaction::LunarBloom,
+            bonus: 0.20,
+        },
+    },
+    MoonsignTalentEnhancement {
+        character_name: "Aino",
+        required_level: MoonsignLevel::AscendantGleam,
+        description: desc!("C6: Lunar-Crystallize additional +20% at Ascendant Gleam"),
+        effect: MoonsignTalentEffect::ReactionDmgBonus {
+            reaction: Reaction::LunarCrystallize,
             bonus: 0.20,
         },
     },
@@ -224,19 +301,27 @@ pub fn calculate_benediction_bonus(def: &MoonsignBenedictionDef, stat_value: f64
     (def.rate * stat_value).min(def.max_bonus)
 }
 
+/// Return the raw (unfiltered) moonsign talent enhancements for a character.
+/// Used by `TeamMemberBuilder` to populate `TeamMember::moonsign_talent_enhancements`;
+/// the level filter is applied at team resolution time.
+#[must_use]
+pub fn all_moonsign_talent_enhancements(id: &str) -> &'static [MoonsignTalentEnhancement] {
+    match id {
+        "lauma" => LAUMA_TALENT_ENHANCEMENTS,
+        "flins" => FLINS_TALENT_ENHANCEMENTS,
+        "nefer" => NEFER_TALENT_ENHANCEMENTS,
+        "aino" => AINO_TALENT_ENHANCEMENTS,
+        _ => &[],
+    }
+}
+
 /// Get talent enhancements for a character, filtered by moonsign level.
 #[must_use]
 pub fn find_moonsign_talent_enhancements(
     id: &str,
     level: MoonsignLevel,
 ) -> Vec<&'static MoonsignTalentEnhancement> {
-    let enhancements: &[MoonsignTalentEnhancement] = match id {
-        "lauma" => LAUMA_TALENT_ENHANCEMENTS,
-        "flins" => FLINS_TALENT_ENHANCEMENTS,
-        "nefer" => NEFER_TALENT_ENHANCEMENTS,
-        "aino" => AINO_TALENT_ENHANCEMENTS,
-        _ => &[],
-    };
+    let enhancements: &[MoonsignTalentEnhancement] = all_moonsign_talent_enhancements(id);
     enhancements
         .iter()
         .filter(|e| {
@@ -333,16 +418,22 @@ mod tests {
     #[test]
     fn test_aino_talent_enhancements_at_ascendant_gleam() {
         let enhancements = find_moonsign_talent_enhancements("aino", MoonsignLevel::AscendantGleam);
-        // NascentGleam (+15%) + AscendantGleam (+20%) = 2 enhancements
-        assert_eq!(enhancements.len(), 2);
+        // 5 Nascent (+15% each) + 5 Ascendant (+20% each) = 10 enhancements
+        // covering ElectroCharged / Bloom / LunarElectroCharged / LunarBloom /
+        // LunarCrystallize per B3 fix.
+        assert_eq!(enhancements.len(), 10);
     }
 
     #[test]
     fn test_aino_talent_enhancements_at_nascent_gleam() {
         let enhancements = find_moonsign_talent_enhancements("aino", MoonsignLevel::NascentGleam);
-        // C6 base +15% activates at NascentGleam
-        assert_eq!(enhancements.len(), 1);
-        assert_eq!(enhancements[0].required_level, MoonsignLevel::NascentGleam);
+        // 5 NascentGleam entries for the 5 affected reactions.
+        assert_eq!(enhancements.len(), 5);
+        assert!(
+            enhancements
+                .iter()
+                .all(|e| e.required_level == MoonsignLevel::NascentGleam)
+        );
     }
 
     #[test]

--- a/crates/data/src/team_builder.rs
+++ b/crates/data/src/team_builder.rs
@@ -233,6 +233,9 @@ impl TeamMemberBuilder {
                 rate: def.rate,
                 max_bonus: def.max_bonus,
             }),
+            moonsign_talent_enhancements: crate::moonsign_chars::all_moonsign_talent_enhancements(
+                self.character.id,
+            ),
         }
     }
 

--- a/crates/data/tests/issue_70_geo_dendro_passives.rs
+++ b/crates/data/tests/issue_70_geo_dendro_passives.rs
@@ -28,6 +28,7 @@ fn dummy_member(element: Element, base_def: f64) -> TeamMember {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     }
 }
 

--- a/crates/data/tests/issue_71_other_passives.rs
+++ b/crates/data/tests/issue_71_other_passives.rs
@@ -27,6 +27,7 @@ fn dummy_member(element: Element, base_def: f64) -> TeamMember {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     }
 }
 

--- a/crates/data/tests/issue_72_elemental_crit_dmg.rs
+++ b/crates/data/tests/issue_72_elemental_crit_dmg.rs
@@ -28,6 +28,7 @@ fn dummy_member(element: Element) -> TeamMember {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     }
 }
 

--- a/crates/data/tests/issue_73_cleanup.rs
+++ b/crates/data/tests/issue_73_cleanup.rs
@@ -30,6 +30,7 @@ fn dummy_member(element: Element) -> TeamMember {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     }
 }
 

--- a/crates/data/tests/issue_74_collei_c6.rs
+++ b/crates/data/tests/issue_74_collei_c6.rs
@@ -27,6 +27,7 @@ fn dummy_member(element: Element) -> TeamMember {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     }
 }
 

--- a/crates/data/tests/meta_team_edge_cases.rs
+++ b/crates/data/tests/meta_team_edge_cases.rs
@@ -62,6 +62,7 @@ fn edge_res_shred_stacking() {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     };
 
     let team = [dps, kazuha, zhongli];
@@ -379,6 +380,7 @@ fn edge_furina_fanfare_scaling() {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     };
 
     let team_no_stacks = [furina, dps.clone()];
@@ -748,6 +750,7 @@ fn edge_bennett_c6_pyro_dmg() {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     };
 
     let team = [bennett_c6, dps];

--- a/crates/data/tests/meta_team_verification.rs
+++ b/crates/data/tests/meta_team_verification.rs
@@ -1355,6 +1355,7 @@ fn cross_team_bennett_buff_consistency() {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     };
 
     let dps2 = TeamMember {
@@ -1373,6 +1374,7 @@ fn cross_team_bennett_buff_consistency() {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     };
 
     let team1 = [bennett.clone(), dps1];

--- a/crates/data/tests/team_integration.rs
+++ b/crates/data/tests/team_integration.rs
@@ -33,6 +33,7 @@ fn test_bennett_kazuha_team_damage() {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     };
 
     let team = [bennett, dps];

--- a/crates/good/tests/evaluate_talent_buffs_integration.rs
+++ b/crates/good/tests/evaluate_talent_buffs_integration.rs
@@ -75,6 +75,7 @@ fn test_pipeline_build_member_stats_to_resolve_team() {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     };
 
     let result = genshin_calc_core::resolve_team_stats(&[member], 0, &[]);

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -742,6 +742,7 @@ mod tests {
             is_moonsign: false,
             can_nightsoul: false,
             moonsign_benediction: None,
+            moonsign_talent_enhancements: &[],
         };
         let result = resolve_team_stats(&[dps], 0, &[]).unwrap();
         assert!(result.final_stats.atk > 0.0);


### PR DESCRIPTION
## Summary
- `TeamMember` now carries `moonsign_talent_enhancements`. `resolve_team_stats_detailed` filters by resolved moonsign level and converts `StatBuff` / `ReactionDmgBonus` effects into `ResolvedBuff`s so they flow through `applied_buffs`, `final_stats`, and `DamageContext.reaction_dmg_bonuses` like any other team buff.
- Previously Nefer A1 (EM+100) and Aino C6 (+15% / +35% reaction DMG) were silently noop'd because `apply_moonsign_enhancements` skipped `StatBuff` and `resolve_team_stats` never touched moonsign data.
- B3 data fix: Aino C6 replaces the over-applying `TransformativeBonus` StatBuff and the single-reaction `ReactionDmgBonus` with exact per-reaction entries for the five reactions listed in the in-game description (ElectroCharged / Bloom / LunarElectroCharged / LunarBloom / LunarCrystallize).

Note: `GrantReactionCrit` has no `BuffableStat` equivalent, so it stays in `MoonsignContext.talent_enhancements` for consumers to apply at the lunar pipeline via `apply_moonsign_enhancements`.

## Test plan
- [x] `crates/core/tests/issue_143_moonsign_enhancement_pipeline.rs`
  - `test_nefer_a1_em_stat_buff_applied_to_target_at_ascendant_gleam` — buff lands in `applied_buffs` and `final_stats.elemental_mastery` reflects +100
  - `test_reaction_dmg_bonus_enhancement_reaches_damage_context` — LunarBloom +20% surfaces, LunarEC unaffected
  - `test_nascent_enhancement_not_applied_at_level_none` — inactive enhancement filtered out
- [x] `cargo test --workspace --all-targets` green (457+ core, all data suites pass)
- [x] `cargo clippy -p genshin-calc-core -p genshin-calc-data --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

## Sequencing
Based on top of #145 (#142). Merge after #145 lands.

## Related
- Closes #143
- Unblocks #144 (Flins A1 dedupe, now that `moonsign_chars.rs` entries actually route through the pipeline)