### PR TITLE
fix(data): dedupe Flins A1 + document moonsign routing policy (#144)

### DIFF
--- a/.claude/rules/conventions.md
+++ b/.claude/rules/conventions.md
@@ -21,6 +21,20 @@
 - チームエネルギー合計系武器（AKUOUMARU/WAVEBREAKERS_FIN/MOUUNS_MOON）はToggle使用（StatScalingは単一キャラのstat参照のみ）
 - `team_builder.rs`注意: `Both(auto, manual)`はauto_valをeval_manualのbase_valueとして渡す。Toggle→auto_val返却、Stacks→auto_val×n
 
+## Moonsign Effect Routing Policy (#144)
+月兆キャラの効果は2系統あるが、**1効果につき1箇所のみ**に登録すること。両方に書くと #143 の moonsign enhancement pipeline によって二重加算される。
+
+- **Moonsign level gated** (Nascent/Ascendant Gleam 条件付き) → `moonsign_chars.rs::*_TALENT_ENHANCEMENTS`
+  - 例: Flins A1 "Symphony of Winter" (Ascendant Gleam で +20%), Aino C6 (Nascent +15% / Ascendant +35%), Lauma A1 crit grants, Nefer A1 EM+100
+  - `resolve_team_stats` がチームレベル判定後に自動配線 (`StatBuff` → `applied_buffs`, `ReactionDmgBonus` → `damage_context.reaction_dmg_bonuses`)
+  - `GrantReactionCrit` のみ `apply_moonsign_enhancements` 経由で lunar pipeline に手動適用必要
+  - reaction 複数対象の場合は個別エントリに展開すること (`ReactionDmgBonus` が単一 reaction のみ受け付けるため)
+- **Level gate 無依存** (凸・天賦レベルのみ条件) → `talent_buffs/<element>.rs::TalentBuffDef`
+  - 例: Flins C6 self/team (C6 単独条件), Columbina C4/C6, Nefer C6 lunar bloom +15%
+  - reaction 単一ターゲティングには `BuffableStat::ReactionDmgBonus(reaction)` を使用 (`TransformativeBonus` は全変化反応に波及するため対象外)
+
+新規月兆効果追加時は上記 routing decision を PR description に明記すること。
+
 ## Critical Change Warning
 - `DamageInput`/`LunarInput`/`TeamMember`変更時は全構築箇所（テスト・docコメント・README・examples含む）を一括修正すること（コンパイル不能防止）
 - `TalentBuffDef.name`変更時は全`.activate()`呼び出し箇所をGrepで検索・一括更新すること（テスト内の`.activate("旧名")`が残ると実行時に無視される）

--- a/crates/core/src/enemy.rs
+++ b/crates/core/src/enemy.rs
@@ -745,6 +745,7 @@ mod tests {
             is_moonsign: false,
             can_nightsoul: false,
             moonsign_benediction: None,
+            moonsign_talent_enhancements: &[],
         };
 
         let support = TeamMember {
@@ -788,6 +789,7 @@ mod tests {
             is_moonsign: false,
             can_nightsoul: false,
             moonsign_benediction: None,
+            moonsign_talent_enhancements: &[],
         };
 
         let team = vec![dps, support];

--- a/crates/core/src/enemy.rs
+++ b/crates/core/src/enemy.rs
@@ -744,6 +744,7 @@ mod tests {
             buffs_provided: vec![],
             is_moonsign: false,
             can_nightsoul: false,
+            moonsign_benediction: None,
         };
 
         let support = TeamMember {
@@ -786,6 +787,7 @@ mod tests {
             ],
             is_moonsign: false,
             can_nightsoul: false,
+            moonsign_benediction: None,
         };
 
         let team = vec![dps, support];

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -34,6 +34,8 @@
 //!     buffs_provided: vec![],
 //!     is_moonsign: false,
 //!     can_nightsoul: false,
+//!     moonsign_benediction: None,
+//!     moonsign_talent_enhancements: &[],
 //! };
 //! let support = TeamMember {
 //!     element: Element::Pyro,
@@ -52,6 +54,8 @@
 //!     }],
 //!     is_moonsign: false,
 //!     can_nightsoul: false,
+//!     moonsign_benediction: None,
+//!     moonsign_talent_enhancements: &[],
 //! };
 //! let result = resolve_team_stats(&[dps, support], 0, &[]).unwrap();
 //! assert!(result.final_stats.atk > 900.0); // DPS gets Bennett's ATK buff

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -134,10 +134,11 @@ pub use lunar::{
     DirectLunarInput, LunarInput, LunarResult, calculate_direct_lunar, calculate_lunar,
 };
 pub use moonsign::{
-    LunarContribution, MoonsignBenediction, MoonsignContext, MoonsignLevel, MoonsignTalentEffect,
-    MoonsignTalentEnhancement, NonMoonsignLunarBuff, apply_moonsign_enhancements,
-    calculate_lunar_team, calculate_non_moonsign_bonus, determine_moonsign_level,
-    non_moonsign_scaling, resolve_moonsign_context, select_non_moonsign_buff,
+    LunarContribution, MoonsignBenediction, MoonsignBenedictionSpec, MoonsignContext,
+    MoonsignLevel, MoonsignTalentEffect, MoonsignTalentEnhancement, NonMoonsignLunarBuff,
+    apply_moonsign_enhancements, calculate_lunar_team, calculate_non_moonsign_bonus,
+    determine_moonsign_level, non_moonsign_scaling, resolve_moonsign_context,
+    select_non_moonsign_buff,
 };
 pub use reaction::{Reaction, ReactionCategory, determine_reaction};
 pub use resonance::{

--- a/crates/core/src/moonsign.rs
+++ b/crates/core/src/moonsign.rs
@@ -28,6 +28,41 @@ pub struct MoonsignBenediction {
     pub enabled_reactions: Vec<Reaction>,
 }
 
+/// Scaling specification for a Moonsign Benediction passive, attached to a
+/// [`crate::TeamMember`]. The final `base_dmg_bonus` is derived from the
+/// member's own stats at team resolution time.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MoonsignBenedictionSpec {
+    /// Lunar reaction types this character enables.
+    pub enabled_reactions: Vec<Reaction>,
+    /// Stat used for bonus scaling. `None` = no personal scaling (e.g. Aino).
+    pub scaling_stat: Option<ScalingStat>,
+    /// Rate per 1 unit of stat.
+    pub rate: f64,
+    /// Maximum bonus value (cap, decimal form).
+    pub max_bonus: f64,
+}
+
+impl MoonsignBenedictionSpec {
+    /// Resolve the spec against a member's stats into a [`MoonsignBenediction`].
+    #[must_use]
+    pub fn resolve(&self, stats: &crate::stats::Stats) -> MoonsignBenediction {
+        let bonus = match self.scaling_stat {
+            Some(ScalingStat::Atk) | Some(ScalingStat::TotalAtk) => {
+                (self.rate * stats.atk).min(self.max_bonus)
+            }
+            Some(ScalingStat::Hp) => (self.rate * stats.hp).min(self.max_bonus),
+            Some(ScalingStat::Def) => (self.rate * stats.def).min(self.max_bonus),
+            Some(ScalingStat::Em) => (self.rate * stats.elemental_mastery).min(self.max_bonus),
+            Some(ScalingStat::CritRate) | None => 0.0,
+        };
+        MoonsignBenediction {
+            base_dmg_bonus: bonus,
+            enabled_reactions: self.enabled_reactions.clone(),
+        }
+    }
+}
+
 /// Moonsign-level dependent talent enhancement.
 ///
 /// Note: only `Serialize` is derived (not `Deserialize`) because `&'static str`

--- a/crates/core/src/moonsign.rs
+++ b/crates/core/src/moonsign.rs
@@ -285,7 +285,9 @@ pub fn apply_moonsign_enhancements(
                 }
             }
             MoonsignTalentEffect::StatBuff { .. } => {
-                // StatBuff is applied at the stat-profile level, not directly to LunarInput
+                // StatBuff is routed through `resolve_team_stats` into
+                // `applied_buffs` / `final_stats` (Issue #143), not through
+                // this per-lunar-input helper.
             }
         }
     }

--- a/crates/core/src/team.rs
+++ b/crates/core/src/team.rs
@@ -3,6 +3,9 @@ use serde::{Deserialize, Serialize};
 use crate::buff_types::BuffableStat;
 use crate::enemy::{EnemyDebuffs, collect_enemy_debuffs};
 use crate::error::CalcError;
+use crate::moonsign::{
+    MoonsignBenediction, MoonsignContext, non_moonsign_scaling, resolve_moonsign_context,
+};
 use crate::reaction::{Reaction, ReactionCategory};
 use crate::resonance::{
     ElementalResonance, determine_resonances, resonance_buffs, resonance_conditional_buffs,
@@ -54,6 +57,10 @@ pub struct TeamMember {
     pub is_moonsign: bool,
     /// Whether this character can use Nightsoul's Blessing (夜魂の加護).
     pub can_nightsoul: bool,
+    /// Moonsign Benediction passive spec, if the character has one.
+    /// Used by `resolve_team_stats` to build [`crate::MoonsignContext`].
+    #[serde(default)]
+    pub moonsign_benediction: Option<crate::moonsign::MoonsignBenedictionSpec>,
 }
 
 /// Aggregated attack-type-specific DMG bonuses, flat DMG, and reaction bonuses
@@ -147,7 +154,10 @@ impl DamageContext {
 }
 
 /// Detailed result of team buff resolution.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+///
+/// Only `Serialize` is derived because [`MoonsignContext::talent_enhancements`]
+/// contains `&'static str` fields (Deserialize not supported).
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct TeamResolveResult {
     /// Stats before team buffs.
     pub base_stats: Stats,
@@ -161,6 +171,9 @@ pub struct TeamResolveResult {
     pub damage_context: DamageContext,
     /// Enemy resistance and DEF reduction from team debuffs.
     pub enemy_debuffs: EnemyDebuffs,
+    /// Team-level Moonsign context (level, per-reaction base DMG bonus,
+    /// non-moonsign lunar bonus, talent enhancements).
+    pub moonsign_context: crate::moonsign::MoonsignContext,
 }
 
 /// Returns true if the buff is unconditional (can be applied to StatProfile directly).
@@ -403,6 +416,48 @@ pub fn resolve_team_stats(
     resolve_team_stats_detailed(team, target_index, resonance_activations)
 }
 
+/// Build a [`MoonsignContext`] from a team by resolving each member's
+/// `moonsign_benediction` spec against their own base stats, counting moonsign
+/// members for the level, and computing the non-moonsign lunar bonus cap from
+/// the strongest non-moonsign member.
+fn build_moonsign_context(team: &[TeamMember]) -> MoonsignContext {
+    let moonsign_count = team.iter().filter(|m| m.is_moonsign).count();
+
+    let benedictions: Vec<MoonsignBenediction> = team
+        .iter()
+        .filter_map(|m| {
+            m.moonsign_benediction.as_ref().map(|spec| {
+                let stats = combine_stats(&m.stats).unwrap_or_default();
+                spec.resolve(&stats)
+            })
+        })
+        .collect();
+
+    let non_moonsign_bonus = if moonsign_count >= 2 {
+        team.iter()
+            .filter(|m| !m.is_moonsign)
+            .map(|m| {
+                let stats = combine_stats(&m.stats).unwrap_or_default();
+                let buff = non_moonsign_scaling(m.element);
+                let stat_value = match buff.scaling_stat {
+                    crate::types::ScalingStat::Atk | crate::types::ScalingStat::TotalAtk => {
+                        stats.atk
+                    }
+                    crate::types::ScalingStat::Hp => stats.hp,
+                    crate::types::ScalingStat::Def => stats.def,
+                    crate::types::ScalingStat::Em => stats.elemental_mastery,
+                    crate::types::ScalingStat::CritRate => 0.0,
+                };
+                (buff.rate * stat_value).min(buff.max_bonus)
+            })
+            .fold(0.0_f64, f64::max)
+    } else {
+        0.0
+    };
+
+    resolve_moonsign_context(moonsign_count, &benedictions, non_moonsign_bonus, vec![])
+}
+
 /// Resolves team buffs with detailed breakdown.
 ///
 /// `applied_buffs` contains all buffs including conditional ones.
@@ -430,6 +485,7 @@ pub fn resolve_team_stats_detailed(
 
     let damage_context = DamageContext::from_buffs(&applied_buffs);
     let enemy_debuffs = collect_enemy_debuffs(&applied_buffs);
+    let moonsign_context = build_moonsign_context(team);
 
     Ok(TeamResolveResult {
         base_stats,
@@ -437,6 +493,7 @@ pub fn resolve_team_stats_detailed(
         resonances,
         final_stats,
         damage_context,
+        moonsign_context,
         enemy_debuffs,
     })
 }
@@ -463,6 +520,7 @@ mod tests {
             buffs_provided: vec![],
             is_moonsign: false,
             can_nightsoul: false,
+            moonsign_benediction: None,
         }
     }
 

--- a/crates/core/src/team.rs
+++ b/crates/core/src/team.rs
@@ -4,7 +4,8 @@ use crate::buff_types::BuffableStat;
 use crate::enemy::{EnemyDebuffs, collect_enemy_debuffs};
 use crate::error::CalcError;
 use crate::moonsign::{
-    MoonsignBenediction, MoonsignContext, non_moonsign_scaling, resolve_moonsign_context,
+    MoonsignBenediction, MoonsignContext, MoonsignLevel, MoonsignTalentEffect,
+    MoonsignTalentEnhancement, non_moonsign_scaling, resolve_moonsign_context,
 };
 use crate::reaction::{Reaction, ReactionCategory};
 use crate::resonance::{
@@ -61,6 +62,22 @@ pub struct TeamMember {
     /// Used by `resolve_team_stats` to build [`crate::MoonsignContext`].
     #[serde(default)]
     pub moonsign_benediction: Option<crate::moonsign::MoonsignBenedictionSpec>,
+    /// All Moonsign talent enhancements this character may contribute, including
+    /// every `required_level`. `resolve_team_stats` filters by the resolved team
+    /// level and routes `StatBuff` / `ReactionDmgBonus` effects into
+    /// `applied_buffs` / `damage_context` automatically. `GrantReactionCrit`
+    /// effects remain in `moonsign_context.talent_enhancements` and must be
+    /// applied at the lunar pipeline via `apply_moonsign_enhancements`.
+    #[serde(
+        skip_serializing,
+        skip_deserializing,
+        default = "empty_moonsign_enhancements"
+    )]
+    pub moonsign_talent_enhancements: &'static [crate::moonsign::MoonsignTalentEnhancement],
+}
+
+fn empty_moonsign_enhancements() -> &'static [crate::moonsign::MoonsignTalentEnhancement] {
+    &[]
 }
 
 /// Aggregated attack-type-specific DMG bonuses, flat DMG, and reaction bonuses
@@ -455,7 +472,113 @@ fn build_moonsign_context(team: &[TeamMember]) -> MoonsignContext {
         0.0
     };
 
-    resolve_moonsign_context(moonsign_count, &benedictions, non_moonsign_bonus, vec![])
+    let active_enhancements = collect_active_enhancements(team, moonsign_count);
+    resolve_moonsign_context(
+        moonsign_count,
+        &benedictions,
+        non_moonsign_bonus,
+        active_enhancements,
+    )
+}
+
+/// Filter each member's `moonsign_talent_enhancements` by the resolved team
+/// moonsign level and return the flat list of enhancements that are active.
+fn collect_active_enhancements(
+    team: &[TeamMember],
+    moonsign_count: usize,
+) -> Vec<MoonsignTalentEnhancement> {
+    let level = crate::moonsign::determine_moonsign_level(moonsign_count);
+    team.iter()
+        .flat_map(|m| m.moonsign_talent_enhancements.iter())
+        .filter(|e| enhancement_is_active(e.required_level, level))
+        .cloned()
+        .collect()
+}
+
+fn enhancement_is_active(required: MoonsignLevel, current: MoonsignLevel) -> bool {
+    matches!(
+        (required, current),
+        (MoonsignLevel::None, _)
+            | (
+                MoonsignLevel::NascentGleam,
+                MoonsignLevel::NascentGleam | MoonsignLevel::AscendantGleam,
+            )
+            | (MoonsignLevel::AscendantGleam, MoonsignLevel::AscendantGleam)
+    )
+}
+
+/// Convert Moonsign talent enhancements with `StatBuff` / `ReactionDmgBonus`
+/// effects into `ResolvedBuff`s so they flow through the normal team buff
+/// resolution (applied_buffs + final_stats + damage_context).
+///
+/// Each enhancement is attributed to a specific member via
+/// `moonsign_talent_enhancements`, which determines the buff `target` scope
+/// (OnlySelf / Team / TeamExcludeSelf) — the buff is only included in
+/// `applied_buffs` for the target member if the scope matches.
+fn enhancement_buffs_for_target(
+    team: &[TeamMember],
+    target_index: usize,
+    level: MoonsignLevel,
+) -> Vec<ResolvedBuff> {
+    let mut out = Vec::new();
+    for (idx, member) in team.iter().enumerate() {
+        for ench in member.moonsign_talent_enhancements {
+            if !enhancement_is_active(ench.required_level, level) {
+                continue;
+            }
+            match &ench.effect {
+                MoonsignTalentEffect::StatBuff {
+                    stat,
+                    value,
+                    target,
+                } => {
+                    if !target_receives(*target, idx, target_index) {
+                        continue;
+                    }
+                    out.push(ResolvedBuff {
+                        source: format!("Moonsign: {} — {}", ench.character_name, ench.description),
+                        stat: *stat,
+                        value: *value,
+                        target: *target,
+                        origin: Some(format!(
+                            "moonsign:{}:{:?}",
+                            ench.character_name, ench.required_level
+                        )),
+                    });
+                }
+                MoonsignTalentEffect::ReactionDmgBonus { reaction, bonus } => {
+                    // ReactionDmgBonus enhancements are treated as Team by
+                    // default because their game semantics typically benefit
+                    // every reaction triggerer. Future extension: add explicit
+                    // target field to the variant if any effect is self-only.
+                    out.push(ResolvedBuff {
+                        source: format!("Moonsign: {} — {}", ench.character_name, ench.description),
+                        stat: BuffableStat::ReactionDmgBonus(*reaction),
+                        value: *bonus,
+                        target: BuffTarget::Team,
+                        origin: Some(format!(
+                            "moonsign:{}:{:?}",
+                            ench.character_name, ench.required_level
+                        )),
+                    });
+                }
+                MoonsignTalentEffect::GrantReactionCrit { .. } => {
+                    // Intentionally left out — crit grants apply at the lunar
+                    // pipeline via apply_moonsign_enhancements and have no
+                    // BuffableStat equivalent.
+                }
+            }
+        }
+    }
+    out
+}
+
+fn target_receives(target: BuffTarget, provider_idx: usize, target_idx: usize) -> bool {
+    match target {
+        BuffTarget::Team => true,
+        BuffTarget::OnlySelf => provider_idx == target_idx,
+        BuffTarget::TeamExcludeSelf => provider_idx != target_idx,
+    }
 }
 
 /// Resolves team buffs with detailed breakdown.
@@ -476,7 +599,15 @@ pub fn resolve_team_stats_detailed(
     let base_profile = &team[target_index].stats;
     let base_stats = combine_stats(base_profile)?;
 
-    let applied_buffs = collect_buffs(team, target_index, resonance_activations);
+    let moonsign_count = team.iter().filter(|m| m.is_moonsign).count();
+    let moonsign_level = crate::moonsign::determine_moonsign_level(moonsign_count);
+
+    let mut applied_buffs = collect_buffs(team, target_index, resonance_activations);
+    applied_buffs.extend(enhancement_buffs_for_target(
+        team,
+        target_index,
+        moonsign_level,
+    ));
     let buffed_profile = apply_buffs_to_profile(base_profile, &applied_buffs);
     let final_stats = combine_stats(&buffed_profile)?;
 
@@ -521,6 +652,7 @@ mod tests {
             is_moonsign: false,
             can_nightsoul: false,
             moonsign_benediction: None,
+            moonsign_talent_enhancements: &[],
         }
     }
 

--- a/crates/core/src/team.rs
+++ b/crates/core/src/team.rs
@@ -421,6 +421,8 @@ fn dedup_by_origin(buffs: &mut Vec<ResolvedBuff>) {
 ///     buffs_provided: vec![],
 ///     is_moonsign: false,
 ///     can_nightsoul: false,
+///     moonsign_benediction: None,
+///     moonsign_talent_enhancements: &[],
 /// };
 /// let result = resolve_team_stats(&[member], 0, &[]).unwrap();
 /// assert!(result.final_stats.atk > 0.0);

--- a/crates/core/tests/issue_142_moonsign_context_on_team_result.rs
+++ b/crates/core/tests/issue_142_moonsign_context_on_team_result.rs
@@ -31,6 +31,7 @@ fn test_team_resolve_result_has_moonsign_context_field() {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     };
     let result = resolve_team_stats(&[member], 0, &[]).unwrap();
     assert_eq!(result.moonsign_context.level, MoonsignLevel::None);
@@ -58,6 +59,7 @@ fn test_ineffa_solo_exposes_lunar_ec_base_dmg_bonus() {
             rate: 0.00007,
             max_bonus: 0.14,
         }),
+        moonsign_talent_enhancements: &[],
     };
     let result = resolve_team_stats(&[member], 0, &[]).unwrap();
     assert_eq!(result.moonsign_context.level, MoonsignLevel::NascentGleam);
@@ -84,6 +86,7 @@ fn test_two_moonsign_team_ascendant_gleam() {
             rate: 0.00007,
             max_bonus: 0.14,
         }),
+        moonsign_talent_enhancements: &[],
     };
     let columbina = TeamMember {
         element: Element::Hydro,
@@ -105,6 +108,7 @@ fn test_two_moonsign_team_ascendant_gleam() {
             rate: 0.000002,
             max_bonus: 0.07,
         }),
+        moonsign_talent_enhancements: &[],
     };
     let result = resolve_team_stats(&[ineffa, columbina], 0, &[]).unwrap();
     assert_eq!(result.moonsign_context.level, MoonsignLevel::AscendantGleam);
@@ -136,6 +140,7 @@ fn test_non_moonsign_lunar_bonus_computed_for_non_moonsign_members() {
             rate: 0.00007,
             max_bonus: 0.14,
         }),
+        moonsign_talent_enhancements: &[],
     };
     let columbina = TeamMember {
         element: Element::Hydro,
@@ -150,6 +155,7 @@ fn test_non_moonsign_lunar_bonus_computed_for_non_moonsign_members() {
             rate: 0.000002,
             max_bonus: 0.07,
         }),
+        moonsign_talent_enhancements: &[],
     };
     let pyro_dps = TeamMember {
         element: Element::Pyro,
@@ -159,6 +165,7 @@ fn test_non_moonsign_lunar_bonus_computed_for_non_moonsign_members() {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     };
     let result = resolve_team_stats(&[ineffa, columbina, pyro_dps], 0, &[]).unwrap();
     assert!(
@@ -184,6 +191,7 @@ fn test_non_moonsign_lunar_bonus_zero_at_nascent_gleam() {
             rate: 0.00007,
             max_bonus: 0.14,
         }),
+        moonsign_talent_enhancements: &[],
     };
     let pyro_dps = TeamMember {
         element: Element::Pyro,
@@ -193,6 +201,7 @@ fn test_non_moonsign_lunar_bonus_zero_at_nascent_gleam() {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     };
     let result = resolve_team_stats(&[ineffa, pyro_dps], 0, &[]).unwrap();
     assert!((result.moonsign_context.non_moonsign_lunar_bonus - 0.0).abs() < EPSILON);

--- a/crates/core/tests/issue_142_moonsign_context_on_team_result.rs
+++ b/crates/core/tests/issue_142_moonsign_context_on_team_result.rs
@@ -1,0 +1,199 @@
+//! Issue #142: Expose MoonsignContext via TeamResolveResult.
+//!
+//! TeamResolveResult must include a moonsign_context field so consumers can
+//! obtain the per-reaction Base DMG Bonus without passing 0 to LunarInput.
+
+use genshin_calc_core::*;
+
+const EPSILON: f64 = 1e-6;
+
+fn default_profile(base_atk: f64, em: f64) -> StatProfile {
+    StatProfile {
+        base_atk,
+        base_hp: 10000.0,
+        base_def: 500.0,
+        elemental_mastery: em,
+        crit_rate: 0.5,
+        crit_dmg: 1.0,
+        energy_recharge: 1.0,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn test_team_resolve_result_has_moonsign_context_field() {
+    // Single non-moonsign member — moonsign_context should exist and be empty.
+    let member = TeamMember {
+        element: Element::Pyro,
+        weapon_type: WeaponType::Sword,
+        stats: default_profile(2000.0, 0.0),
+        buffs_provided: vec![],
+        is_moonsign: false,
+        can_nightsoul: false,
+        moonsign_benediction: None,
+    };
+    let result = resolve_team_stats(&[member], 0, &[]).unwrap();
+    assert_eq!(result.moonsign_context.level, MoonsignLevel::None);
+    assert!(
+        result
+            .moonsign_context
+            .base_dmg_bonus_by_reaction
+            .is_empty()
+    );
+}
+
+#[test]
+fn test_ineffa_solo_exposes_lunar_ec_base_dmg_bonus() {
+    // Ineffa-like: ATK 2000 → benediction 0.00007 * 2000 = 0.14 for LunarElectroCharged.
+    let member = TeamMember {
+        element: Element::Electro,
+        weapon_type: WeaponType::Catalyst,
+        stats: default_profile(2000.0, 0.0),
+        buffs_provided: vec![],
+        is_moonsign: true,
+        can_nightsoul: false,
+        moonsign_benediction: Some(MoonsignBenedictionSpec {
+            enabled_reactions: vec![Reaction::LunarElectroCharged],
+            scaling_stat: Some(ScalingStat::Atk),
+            rate: 0.00007,
+            max_bonus: 0.14,
+        }),
+    };
+    let result = resolve_team_stats(&[member], 0, &[]).unwrap();
+    assert_eq!(result.moonsign_context.level, MoonsignLevel::NascentGleam);
+    let bonus = result
+        .moonsign_context
+        .base_dmg_bonus_for(Reaction::LunarElectroCharged);
+    assert!((bonus - 0.14).abs() < EPSILON);
+}
+
+#[test]
+fn test_two_moonsign_team_ascendant_gleam() {
+    // Ineffa (+0.14 LunarEC) + Columbina (+0.07 LunarEC/Bloom/Crystallize).
+    // Total LunarEC = 0.21.
+    let ineffa = TeamMember {
+        element: Element::Electro,
+        weapon_type: WeaponType::Catalyst,
+        stats: default_profile(2000.0, 0.0),
+        buffs_provided: vec![],
+        is_moonsign: true,
+        can_nightsoul: false,
+        moonsign_benediction: Some(MoonsignBenedictionSpec {
+            enabled_reactions: vec![Reaction::LunarElectroCharged],
+            scaling_stat: Some(ScalingStat::Atk),
+            rate: 0.00007,
+            max_bonus: 0.14,
+        }),
+    };
+    let columbina = TeamMember {
+        element: Element::Hydro,
+        weapon_type: WeaponType::Catalyst,
+        stats: StatProfile {
+            base_hp: 35000.0,
+            ..default_profile(1000.0, 0.0)
+        },
+        buffs_provided: vec![],
+        is_moonsign: true,
+        can_nightsoul: false,
+        moonsign_benediction: Some(MoonsignBenedictionSpec {
+            enabled_reactions: vec![
+                Reaction::LunarElectroCharged,
+                Reaction::LunarBloom,
+                Reaction::LunarCrystallize,
+            ],
+            scaling_stat: Some(ScalingStat::Hp),
+            rate: 0.000002,
+            max_bonus: 0.07,
+        }),
+    };
+    let result = resolve_team_stats(&[ineffa, columbina], 0, &[]).unwrap();
+    assert_eq!(result.moonsign_context.level, MoonsignLevel::AscendantGleam);
+    let ec = result
+        .moonsign_context
+        .base_dmg_bonus_for(Reaction::LunarElectroCharged);
+    assert!((ec - 0.21).abs() < EPSILON, "LunarEC bonus: {ec}");
+    let bloom = result
+        .moonsign_context
+        .base_dmg_bonus_for(Reaction::LunarBloom);
+    assert!((bloom - 0.07).abs() < EPSILON, "LunarBloom bonus: {bloom}");
+}
+
+#[test]
+fn test_non_moonsign_lunar_bonus_computed_for_non_moonsign_members() {
+    // non_moonsign_lunar_bonus is only active at AscendantGleam (2+ moonsign).
+    // Ineffa + Columbina (both moonsign) + Pyro non-moonsign with 2000 ATK.
+    // Expected: 0.00009 * 2000 = 0.18 (cap 0.36).
+    let ineffa = TeamMember {
+        element: Element::Electro,
+        weapon_type: WeaponType::Catalyst,
+        stats: default_profile(2000.0, 0.0),
+        buffs_provided: vec![],
+        is_moonsign: true,
+        can_nightsoul: false,
+        moonsign_benediction: Some(MoonsignBenedictionSpec {
+            enabled_reactions: vec![Reaction::LunarElectroCharged],
+            scaling_stat: Some(ScalingStat::Atk),
+            rate: 0.00007,
+            max_bonus: 0.14,
+        }),
+    };
+    let columbina = TeamMember {
+        element: Element::Hydro,
+        weapon_type: WeaponType::Catalyst,
+        stats: default_profile(1000.0, 0.0),
+        buffs_provided: vec![],
+        is_moonsign: true,
+        can_nightsoul: false,
+        moonsign_benediction: Some(MoonsignBenedictionSpec {
+            enabled_reactions: vec![Reaction::LunarBloom],
+            scaling_stat: Some(ScalingStat::Hp),
+            rate: 0.000002,
+            max_bonus: 0.07,
+        }),
+    };
+    let pyro_dps = TeamMember {
+        element: Element::Pyro,
+        weapon_type: WeaponType::Sword,
+        stats: default_profile(2000.0, 0.0),
+        buffs_provided: vec![],
+        is_moonsign: false,
+        can_nightsoul: false,
+        moonsign_benediction: None,
+    };
+    let result = resolve_team_stats(&[ineffa, columbina, pyro_dps], 0, &[]).unwrap();
+    assert!(
+        (result.moonsign_context.non_moonsign_lunar_bonus - 0.18).abs() < EPSILON,
+        "got {}",
+        result.moonsign_context.non_moonsign_lunar_bonus
+    );
+}
+
+#[test]
+fn test_non_moonsign_lunar_bonus_zero_at_nascent_gleam() {
+    // At NascentGleam (1 moonsign), non_moonsign_lunar_bonus must stay 0.
+    let ineffa = TeamMember {
+        element: Element::Electro,
+        weapon_type: WeaponType::Catalyst,
+        stats: default_profile(2000.0, 0.0),
+        buffs_provided: vec![],
+        is_moonsign: true,
+        can_nightsoul: false,
+        moonsign_benediction: Some(MoonsignBenedictionSpec {
+            enabled_reactions: vec![Reaction::LunarElectroCharged],
+            scaling_stat: Some(ScalingStat::Atk),
+            rate: 0.00007,
+            max_bonus: 0.14,
+        }),
+    };
+    let pyro_dps = TeamMember {
+        element: Element::Pyro,
+        weapon_type: WeaponType::Sword,
+        stats: default_profile(2000.0, 0.0),
+        buffs_provided: vec![],
+        is_moonsign: false,
+        can_nightsoul: false,
+        moonsign_benediction: None,
+    };
+    let result = resolve_team_stats(&[ineffa, pyro_dps], 0, &[]).unwrap();
+    assert!((result.moonsign_context.non_moonsign_lunar_bonus - 0.0).abs() < EPSILON);
+}

--- a/crates/core/tests/issue_143_moonsign_enhancement_pipeline.rs
+++ b/crates/core/tests/issue_143_moonsign_enhancement_pipeline.rs
@@ -1,0 +1,197 @@
+//! Issue #143: MoonsignTalentEnhancement must flow through the team resolution
+//! pipeline automatically.
+//!
+//! - `StatBuff` must surface in `applied_buffs` and (for unconditional stat kinds)
+//!   reflect in `final_stats`.
+//! - `ReactionDmgBonus` must surface in `damage_context.reaction_dmg_bonuses`.
+//! - `GrantReactionCrit` remains in `moonsign_context.talent_enhancements` for
+//!   consumers to apply via `apply_moonsign_enhancements`.
+
+use genshin_calc_core::*;
+
+const EPSILON: f64 = 1e-6;
+
+fn base_profile(atk: f64, em: f64) -> StatProfile {
+    StatProfile {
+        base_atk: atk,
+        base_hp: 10000.0,
+        base_def: 500.0,
+        elemental_mastery: em,
+        crit_rate: 0.5,
+        crit_dmg: 1.0,
+        energy_recharge: 1.0,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn test_nefer_a1_em_stat_buff_applied_to_target_at_ascendant_gleam() {
+    // Nefer A1 at Ascendant grants EM +100 to self. Set up a 2-moonsign team
+    // (Ascendant level) and resolve targeting Nefer.
+    let nefer_enhancement: &'static [MoonsignTalentEnhancement] =
+        Box::leak(Box::new([MoonsignTalentEnhancement {
+            character_name: "Nefer",
+            required_level: MoonsignLevel::AscendantGleam,
+            description: "Nefer A1 EM +100 at Ascendant Gleam",
+            effect: MoonsignTalentEffect::StatBuff {
+                stat: BuffableStat::ElementalMastery,
+                value: 100.0,
+                target: BuffTarget::OnlySelf,
+            },
+        }]));
+    let nefer = TeamMember {
+        element: Element::Dendro,
+        weapon_type: WeaponType::Catalyst,
+        stats: base_profile(1500.0, 500.0),
+        buffs_provided: vec![],
+        is_moonsign: true,
+        can_nightsoul: false,
+        moonsign_benediction: Some(MoonsignBenedictionSpec {
+            enabled_reactions: vec![Reaction::LunarBloom],
+            scaling_stat: Some(ScalingStat::Em),
+            rate: 0.000175,
+            max_bonus: 0.14,
+        }),
+        moonsign_talent_enhancements: nefer_enhancement,
+    };
+    let columbina = TeamMember {
+        element: Element::Hydro,
+        weapon_type: WeaponType::Catalyst,
+        stats: base_profile(1000.0, 0.0),
+        buffs_provided: vec![],
+        is_moonsign: true,
+        can_nightsoul: false,
+        moonsign_benediction: Some(MoonsignBenedictionSpec {
+            enabled_reactions: vec![
+                Reaction::LunarElectroCharged,
+                Reaction::LunarBloom,
+                Reaction::LunarCrystallize,
+            ],
+            scaling_stat: Some(ScalingStat::Hp),
+            rate: 0.000002,
+            max_bonus: 0.07,
+        }),
+        moonsign_talent_enhancements: &[],
+    };
+
+    let result = resolve_team_stats(&[nefer, columbina], 0, &[]).unwrap();
+
+    // applied_buffs must contain the EM +100 buff
+    let em_buff = result.applied_buffs.iter().find(|b| {
+        matches!(b.stat, BuffableStat::ElementalMastery) && (b.value - 100.0).abs() < EPSILON
+    });
+    assert!(
+        em_buff.is_some(),
+        "expected EM +100 in applied_buffs, got: {:?}",
+        result
+            .applied_buffs
+            .iter()
+            .map(|b| (&b.source, &b.stat, b.value))
+            .collect::<Vec<_>>()
+    );
+
+    // final_stats.elemental_mastery reflects the +100 on top of base 500
+    assert!(
+        (result.final_stats.elemental_mastery - 600.0).abs() < EPSILON,
+        "got {}",
+        result.final_stats.elemental_mastery
+    );
+}
+
+#[test]
+fn test_reaction_dmg_bonus_enhancement_reaches_damage_context() {
+    // Synthetic Moonsign char granting LunarBloom +20% at Ascendant Gleam (self).
+    let ench: &'static [MoonsignTalentEnhancement] =
+        Box::leak(Box::new([MoonsignTalentEnhancement {
+            character_name: "TestBloomBoost",
+            required_level: MoonsignLevel::AscendantGleam,
+            description: "LunarBloom +20%",
+            effect: MoonsignTalentEffect::ReactionDmgBonus {
+                reaction: Reaction::LunarBloom,
+                bonus: 0.20,
+            },
+        }]));
+    let bloom_char = TeamMember {
+        element: Element::Dendro,
+        weapon_type: WeaponType::Catalyst,
+        stats: base_profile(1500.0, 500.0),
+        buffs_provided: vec![],
+        is_moonsign: true,
+        can_nightsoul: false,
+        moonsign_benediction: Some(MoonsignBenedictionSpec {
+            enabled_reactions: vec![Reaction::LunarBloom],
+            scaling_stat: Some(ScalingStat::Em),
+            rate: 0.000175,
+            max_bonus: 0.14,
+        }),
+        moonsign_talent_enhancements: ench,
+    };
+    let partner = TeamMember {
+        element: Element::Hydro,
+        weapon_type: WeaponType::Catalyst,
+        stats: base_profile(1000.0, 0.0),
+        buffs_provided: vec![],
+        is_moonsign: true,
+        can_nightsoul: false,
+        moonsign_benediction: Some(MoonsignBenedictionSpec {
+            enabled_reactions: vec![Reaction::LunarBloom],
+            scaling_stat: Some(ScalingStat::Hp),
+            rate: 0.000002,
+            max_bonus: 0.07,
+        }),
+        moonsign_talent_enhancements: &[],
+    };
+
+    let result = resolve_team_stats(&[bloom_char, partner], 0, &[]).unwrap();
+
+    let bloom_bonus = result
+        .damage_context
+        .reaction_bonus_for(Reaction::LunarBloom);
+    assert!(
+        (bloom_bonus - 0.20).abs() < EPSILON,
+        "expected LunarBloom +20% in damage_context, got {}",
+        bloom_bonus
+    );
+    // Non-matching reaction must not be affected
+    let ec_bonus = result
+        .damage_context
+        .reaction_bonus_for(Reaction::LunarElectroCharged);
+    assert!(
+        (ec_bonus - 0.0).abs() < EPSILON,
+        "LunarEC must not receive LunarBloom enhancement, got {}",
+        ec_bonus
+    );
+}
+
+#[test]
+fn test_nascent_enhancement_not_applied_at_level_none() {
+    // Enhancement required_level = NascentGleam. With 0 moonsign members the
+    // team level is None, so the enhancement must NOT be applied.
+    let ench: &'static [MoonsignTalentEnhancement] =
+        Box::leak(Box::new([MoonsignTalentEnhancement {
+            character_name: "TestNone",
+            required_level: MoonsignLevel::NascentGleam,
+            description: "dummy",
+            effect: MoonsignTalentEffect::StatBuff {
+                stat: BuffableStat::ElementalMastery,
+                value: 100.0,
+                target: BuffTarget::OnlySelf,
+            },
+        }]));
+    let non_moonsign = TeamMember {
+        element: Element::Pyro,
+        weapon_type: WeaponType::Sword,
+        stats: base_profile(1500.0, 0.0),
+        buffs_provided: vec![],
+        is_moonsign: false,
+        can_nightsoul: false,
+        moonsign_benediction: None,
+        moonsign_talent_enhancements: ench,
+    };
+    let result = resolve_team_stats(&[non_moonsign], 0, &[]).unwrap();
+    // No EM buff from inactive enhancement
+    let has_em_buff = result.applied_buffs.iter().any(|b| {
+        matches!(b.stat, BuffableStat::ElementalMastery) && (b.value - 100.0).abs() < EPSILON
+    });
+    assert!(!has_em_buff, "inactive enhancement must not produce buffs");
+}

--- a/crates/data/src/moonsign_chars.rs
+++ b/crates/data/src/moonsign_chars.rs
@@ -177,26 +177,103 @@ pub const NEFER_TALENT_ENHANCEMENTS: &[MoonsignTalentEnhancement] = &[MoonsignTa
 }];
 
 /// Talent enhancements for Aino.
-/// C6 reaction DMG bonus varies by Moonsign level: Lv1=+15%, Lv2=+35%.
+/// C6: For 15s after Burst, DMG from nearby active characters' Electro-Charged,
+/// Bloom, Lunar-Charged, Lunar-Bloom, and Lunar-Crystallize reactions is
+/// increased. Nascent Gleam grants +15%, Ascendant Gleam adds another +20%
+/// (total +35%).
+///
+/// Implementation note: each `ReactionDmgBonus` variant targets a single
+/// reaction, so the 5 affected reactions expand into 5 entries per level.
 pub const AINO_TALENT_ENHANCEMENTS: &[MoonsignTalentEnhancement] = &[
+    // Nascent Gleam: +15% to each of the 5 reactions.
     MoonsignTalentEnhancement {
         character_name: "Aino",
         required_level: MoonsignLevel::NascentGleam,
-        description: desc!("C6: At Nascent Gleam+, reaction DMG +15% for 15s after Burst"),
-        effect: MoonsignTalentEffect::StatBuff {
-            stat: BuffableStat::TransformativeBonus,
-            value: 0.15,
-            target: BuffTarget::Team,
+        description: desc!("C6: Electro-Charged +15% for 15s after Burst (Nascent Gleam+)"),
+        effect: MoonsignTalentEffect::ReactionDmgBonus {
+            reaction: Reaction::ElectroCharged,
+            bonus: 0.15,
+        },
+    },
+    MoonsignTalentEnhancement {
+        character_name: "Aino",
+        required_level: MoonsignLevel::NascentGleam,
+        description: desc!("C6: Bloom +15% for 15s after Burst (Nascent Gleam+)"),
+        effect: MoonsignTalentEffect::ReactionDmgBonus {
+            reaction: Reaction::Bloom,
+            bonus: 0.15,
+        },
+    },
+    MoonsignTalentEnhancement {
+        character_name: "Aino",
+        required_level: MoonsignLevel::NascentGleam,
+        description: desc!("C6: Lunar-Charged +15% for 15s after Burst (Nascent Gleam+)"),
+        effect: MoonsignTalentEffect::ReactionDmgBonus {
+            reaction: Reaction::LunarElectroCharged,
+            bonus: 0.15,
+        },
+    },
+    MoonsignTalentEnhancement {
+        character_name: "Aino",
+        required_level: MoonsignLevel::NascentGleam,
+        description: desc!("C6: Lunar-Bloom +15% for 15s after Burst (Nascent Gleam+)"),
+        effect: MoonsignTalentEffect::ReactionDmgBonus {
+            reaction: Reaction::LunarBloom,
+            bonus: 0.15,
+        },
+    },
+    MoonsignTalentEnhancement {
+        character_name: "Aino",
+        required_level: MoonsignLevel::NascentGleam,
+        description: desc!("C6: Lunar-Crystallize +15% for 15s after Burst (Nascent Gleam+)"),
+        effect: MoonsignTalentEffect::ReactionDmgBonus {
+            reaction: Reaction::LunarCrystallize,
+            bonus: 0.15,
+        },
+    },
+    // Ascendant Gleam: additional +20% on each of the same 5 reactions.
+    MoonsignTalentEnhancement {
+        character_name: "Aino",
+        required_level: MoonsignLevel::AscendantGleam,
+        description: desc!("C6: Electro-Charged additional +20% at Ascendant Gleam"),
+        effect: MoonsignTalentEffect::ReactionDmgBonus {
+            reaction: Reaction::ElectroCharged,
+            bonus: 0.20,
         },
     },
     MoonsignTalentEnhancement {
         character_name: "Aino",
         required_level: MoonsignLevel::AscendantGleam,
-        description: desc!(
-            "C6: At Ascendant Gleam, reaction DMG bonus increases by +20% (total +35%)"
-        ),
+        description: desc!("C6: Bloom additional +20% at Ascendant Gleam"),
+        effect: MoonsignTalentEffect::ReactionDmgBonus {
+            reaction: Reaction::Bloom,
+            bonus: 0.20,
+        },
+    },
+    MoonsignTalentEnhancement {
+        character_name: "Aino",
+        required_level: MoonsignLevel::AscendantGleam,
+        description: desc!("C6: Lunar-Charged additional +20% at Ascendant Gleam"),
         effect: MoonsignTalentEffect::ReactionDmgBonus {
             reaction: Reaction::LunarElectroCharged,
+            bonus: 0.20,
+        },
+    },
+    MoonsignTalentEnhancement {
+        character_name: "Aino",
+        required_level: MoonsignLevel::AscendantGleam,
+        description: desc!("C6: Lunar-Bloom additional +20% at Ascendant Gleam"),
+        effect: MoonsignTalentEffect::ReactionDmgBonus {
+            reaction: Reaction::LunarBloom,
+            bonus: 0.20,
+        },
+    },
+    MoonsignTalentEnhancement {
+        character_name: "Aino",
+        required_level: MoonsignLevel::AscendantGleam,
+        description: desc!("C6: Lunar-Crystallize additional +20% at Ascendant Gleam"),
+        effect: MoonsignTalentEffect::ReactionDmgBonus {
+            reaction: Reaction::LunarCrystallize,
             bonus: 0.20,
         },
     },
@@ -224,19 +301,27 @@ pub fn calculate_benediction_bonus(def: &MoonsignBenedictionDef, stat_value: f64
     (def.rate * stat_value).min(def.max_bonus)
 }
 
+/// Return the raw (unfiltered) moonsign talent enhancements for a character.
+/// Used by `TeamMemberBuilder` to populate `TeamMember::moonsign_talent_enhancements`;
+/// the level filter is applied at team resolution time.
+#[must_use]
+pub fn all_moonsign_talent_enhancements(id: &str) -> &'static [MoonsignTalentEnhancement] {
+    match id {
+        "lauma" => LAUMA_TALENT_ENHANCEMENTS,
+        "flins" => FLINS_TALENT_ENHANCEMENTS,
+        "nefer" => NEFER_TALENT_ENHANCEMENTS,
+        "aino" => AINO_TALENT_ENHANCEMENTS,
+        _ => &[],
+    }
+}
+
 /// Get talent enhancements for a character, filtered by moonsign level.
 #[must_use]
 pub fn find_moonsign_talent_enhancements(
     id: &str,
     level: MoonsignLevel,
 ) -> Vec<&'static MoonsignTalentEnhancement> {
-    let enhancements: &[MoonsignTalentEnhancement] = match id {
-        "lauma" => LAUMA_TALENT_ENHANCEMENTS,
-        "flins" => FLINS_TALENT_ENHANCEMENTS,
-        "nefer" => NEFER_TALENT_ENHANCEMENTS,
-        "aino" => AINO_TALENT_ENHANCEMENTS,
-        _ => &[],
-    };
+    let enhancements: &[MoonsignTalentEnhancement] = all_moonsign_talent_enhancements(id);
     enhancements
         .iter()
         .filter(|e| {
@@ -333,16 +418,22 @@ mod tests {
     #[test]
     fn test_aino_talent_enhancements_at_ascendant_gleam() {
         let enhancements = find_moonsign_talent_enhancements("aino", MoonsignLevel::AscendantGleam);
-        // NascentGleam (+15%) + AscendantGleam (+20%) = 2 enhancements
-        assert_eq!(enhancements.len(), 2);
+        // 5 Nascent (+15% each) + 5 Ascendant (+20% each) = 10 enhancements
+        // covering ElectroCharged / Bloom / LunarElectroCharged / LunarBloom /
+        // LunarCrystallize per B3 fix.
+        assert_eq!(enhancements.len(), 10);
     }
 
     #[test]
     fn test_aino_talent_enhancements_at_nascent_gleam() {
         let enhancements = find_moonsign_talent_enhancements("aino", MoonsignLevel::NascentGleam);
-        // C6 base +15% activates at NascentGleam
-        assert_eq!(enhancements.len(), 1);
-        assert_eq!(enhancements[0].required_level, MoonsignLevel::NascentGleam);
+        // 5 NascentGleam entries for the 5 affected reactions.
+        assert_eq!(enhancements.len(), 5);
+        assert!(
+            enhancements
+                .iter()
+                .all(|e| e.required_level == MoonsignLevel::NascentGleam)
+        );
     }
 
     #[test]

--- a/crates/data/src/talent_buffs/electro.rs
+++ b/crates/data/src/talent_buffs/electro.rs
@@ -90,28 +90,14 @@ static LISA_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
 }];
 
 // ===== Flins =====
-// A1 passive "Symphony of Winter": Lunar-Charged DMG +20% (self, Toggle)
+// A1 "Symphony of Winter" (Lunar-Charged DMG +20% at Ascendant Gleam): moved
+// to moonsign_chars.rs::FLINS_TALENT_ENHANCEMENTS (Issue #144) — it is a
+// Moonsign-level-gated effect, routed via the moonsign enhancement pipeline.
 // A4 passive "Whispering Flame": EM += total ATK × 0.08, capped at 160
 // C4 "Night on Bald Mountain": ATK +20%
 // C2: Opponents' Electro RES -25% during Ascendant Gleam Moonsign
 // C6: Flins's Lunar-Charged DMG +35%, Party Lunar-Charged DMG +10% during Moonsign
 static FLINS_BUFFS: &[TalentBuffDef] = &[
-    TalentBuffDef {
-        name: "Symphony of Winter",
-        description: desc!(
-            "A1: Lunar-Charged reactions triggered by Flins deal an additional 20% DMG"
-        ),
-        stat: BuffableStat::TransformativeBonus,
-        base_value: 0.20,
-        scales_with_talent: false,
-        talent_scaling: None,
-        scales_on: None,
-        target: BuffTarget::OnlySelf,
-        source: TalentBuffSource::AscensionPassive(1),
-        min_constellation: 0,
-        cap: None,
-        activation: Some(Activation::Manual(ManualCondition::Toggle)),
-    },
     TalentBuffDef {
         name: "Whispering Flame EM Bonus",
         description: desc!("A4: Flins gains EM equal to 8% of her total ATK (max 160)"),

--- a/crates/data/src/team_builder.rs
+++ b/crates/data/src/team_builder.rs
@@ -233,6 +233,9 @@ impl TeamMemberBuilder {
                 rate: def.rate,
                 max_bonus: def.max_bonus,
             }),
+            moonsign_talent_enhancements: crate::moonsign_chars::all_moonsign_talent_enhancements(
+                self.character.id,
+            ),
         }
     }
 

--- a/crates/data/src/team_builder.rs
+++ b/crates/data/src/team_builder.rs
@@ -224,6 +224,15 @@ impl TeamMemberBuilder {
             buffs_provided: buffs,
             is_moonsign: is_moonsign_character(self.character.id),
             can_nightsoul: is_nightsoul_character(self.character.id),
+            moonsign_benediction: crate::moonsign_chars::find_moonsign_benediction(
+                self.character.id,
+            )
+            .map(|def| genshin_calc_core::MoonsignBenedictionSpec {
+                enabled_reactions: def.enabled_reactions.to_vec(),
+                scaling_stat: def.scaling_stat,
+                rate: def.rate,
+                max_bonus: def.max_bonus,
+            }),
         }
     }
 

--- a/crates/data/tests/issue_106_113_electro_anemo.rs
+++ b/crates/data/tests/issue_106_113_electro_anemo.rs
@@ -52,40 +52,35 @@ fn test_ororon_total_buff_count() {
     );
 }
 
-// ===== Issue #107: Flins A1 "Symphony of Winter" Lunar-Charged DMG +20% =====
+// ===== Issue #107 / #144: Flins A1 "Symphony of Winter" Lunar-Charged DMG +20% =====
+// Canonical location moved to moonsign_chars.rs::FLINS_TALENT_ENHANCEMENTS (Issue
+// #144). The talent_buffs/electro.rs duplicate was removed to avoid double-count
+// after the moonsign enhancement pipeline (Issue #143) started auto-applying
+// moonsign-level-gated effects.
 
-/// Flins A1 should grant Lunar-Charged DMG +20% (TransformativeBonus, OnlySelf, Toggle)
+/// Flins A1 must live in moonsign_chars.rs and NOT in talent_buffs/.
 #[test]
-fn test_flins_a1_symphony_of_winter_lunar_charged_dmg() {
+fn test_flins_a1_is_not_in_talent_buffs() {
     let buffs = find_talent_buffs("flins").expect("flins buffs not found");
     let a1_buff = buffs
         .iter()
-        .find(|b| b.source == TalentBuffSource::AscensionPassive(1))
-        .expect("Flins A1 buff not found");
-    assert_eq!(
-        a1_buff.stat,
-        BuffableStat::TransformativeBonus,
-        "Flins A1 should use TransformativeBonus for Lunar-Charged DMG"
-    );
+        .find(|b| b.source == TalentBuffSource::AscensionPassive(1));
     assert!(
-        (a1_buff.base_value - 0.20).abs() < EPS,
-        "Flins A1 should be +20%"
-    );
-    assert_eq!(a1_buff.target, BuffTarget::OnlySelf);
-    assert_eq!(
-        a1_buff.activation,
-        Some(Activation::Manual(ManualCondition::Toggle))
+        a1_buff.is_none(),
+        "Flins A1 is moonsign-level-gated and must live in \
+         moonsign_chars.rs::FLINS_TALENT_ENHANCEMENTS, not talent_buffs/"
     );
 }
 
-/// Flins should now have 7 buffs (A1 new, A4, C4 ATK, C4 A4 enhance, C2 res, C6 self, C6 team)
+/// Flins should have 6 talent_buffs entries after A1 was moved out:
+/// A4, C4 ATK, C4 A4 enhance, C2 res, C6 self, C6 team.
 #[test]
 fn test_flins_total_buff_count() {
     let buffs = find_talent_buffs("flins").expect("flins buffs not found");
     assert_eq!(
         buffs.len(),
-        7,
-        "Flins should have 7 buffs (A1 + existing 6)"
+        6,
+        "Flins should have 6 talent_buffs (A1 moved to moonsign_chars.rs)"
     );
 }
 

--- a/crates/data/tests/issue_144_flins_a1_dedupe.rs
+++ b/crates/data/tests/issue_144_flins_a1_dedupe.rs
@@ -1,0 +1,50 @@
+//! Issue #144: Flins A1 "Symphony of Winter" (+20% Lunar-Charged DMG) must not
+//! be double-counted. Canonical source is `moonsign_chars.rs::FLINS_TALENT_ENHANCEMENTS`
+//! (routed automatically by the moonsign pipeline once team reaches Ascendant
+//! Gleam); the duplicate in `talent_buffs/electro.rs` is removed.
+
+use genshin_calc_core::*;
+use genshin_calc_data::{TeamMemberBuilder, find_character, find_weapon, talent_buffs};
+
+const EPSILON: f64 = 1e-6;
+
+#[test]
+fn test_flins_a1_not_registered_in_talent_buffs() {
+    let buffs = talent_buffs::find_talent_buffs("flins").expect("Flins talent buffs");
+    assert!(
+        !buffs.iter().any(|b| b.name == "Symphony of Winter"),
+        "Flins A1 'Symphony of Winter' must not live in talent_buffs (duplicate \
+         with moonsign_chars.rs::FLINS_TALENT_ENHANCEMENTS)"
+    );
+}
+
+#[test]
+fn test_flins_a1_still_routes_at_ascendant_gleam() {
+    let flins_char = find_character("flins").expect("Flins character data");
+    let columbina_char = find_character("columbina").expect("Columbina character data");
+    let weapon = find_weapon("prototype_rancour")
+        .or_else(|| find_weapon("favonius_greatsword"))
+        .or_else(|| find_weapon("the_black_sword"))
+        .expect("a neutral fallback weapon");
+
+    let flins = TeamMemberBuilder::new(flins_char, weapon)
+        .build()
+        .expect("Flins TeamMember");
+    let columbina = TeamMemberBuilder::new(columbina_char, weapon)
+        .build()
+        .expect("Columbina TeamMember");
+
+    let result = resolve_team_stats(&[flins, columbina], 0, &[]).unwrap();
+    assert_eq!(result.moonsign_context.level, MoonsignLevel::AscendantGleam);
+
+    // LunarElectroCharged reaction bonus must include exactly +20% from A1
+    // (no double-count, no missing).
+    let bonus = result
+        .damage_context
+        .reaction_bonus_for(Reaction::LunarElectroCharged);
+    assert!(
+        (bonus - 0.20).abs() < EPSILON,
+        "expected exactly +20% LunarEC bonus, got {}",
+        bonus
+    );
+}

--- a/crates/data/tests/issue_70_geo_dendro_passives.rs
+++ b/crates/data/tests/issue_70_geo_dendro_passives.rs
@@ -28,6 +28,7 @@ fn dummy_member(element: Element, base_def: f64) -> TeamMember {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     }
 }
 

--- a/crates/data/tests/issue_70_geo_dendro_passives.rs
+++ b/crates/data/tests/issue_70_geo_dendro_passives.rs
@@ -27,6 +27,7 @@ fn dummy_member(element: Element, base_def: f64) -> TeamMember {
         buffs_provided: vec![],
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     }
 }
 

--- a/crates/data/tests/issue_71_other_passives.rs
+++ b/crates/data/tests/issue_71_other_passives.rs
@@ -27,6 +27,7 @@ fn dummy_member(element: Element, base_def: f64) -> TeamMember {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     }
 }
 

--- a/crates/data/tests/issue_71_other_passives.rs
+++ b/crates/data/tests/issue_71_other_passives.rs
@@ -26,6 +26,7 @@ fn dummy_member(element: Element, base_def: f64) -> TeamMember {
         buffs_provided: vec![],
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     }
 }
 

--- a/crates/data/tests/issue_72_elemental_crit_dmg.rs
+++ b/crates/data/tests/issue_72_elemental_crit_dmg.rs
@@ -27,6 +27,7 @@ fn dummy_member(element: Element) -> TeamMember {
         buffs_provided: vec![],
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     }
 }
 

--- a/crates/data/tests/issue_72_elemental_crit_dmg.rs
+++ b/crates/data/tests/issue_72_elemental_crit_dmg.rs
@@ -28,6 +28,7 @@ fn dummy_member(element: Element) -> TeamMember {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     }
 }
 

--- a/crates/data/tests/issue_73_cleanup.rs
+++ b/crates/data/tests/issue_73_cleanup.rs
@@ -29,6 +29,7 @@ fn dummy_member(element: Element) -> TeamMember {
         buffs_provided: vec![],
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     }
 }
 

--- a/crates/data/tests/issue_73_cleanup.rs
+++ b/crates/data/tests/issue_73_cleanup.rs
@@ -30,6 +30,7 @@ fn dummy_member(element: Element) -> TeamMember {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     }
 }
 

--- a/crates/data/tests/issue_74_collei_c6.rs
+++ b/crates/data/tests/issue_74_collei_c6.rs
@@ -26,6 +26,7 @@ fn dummy_member(element: Element) -> TeamMember {
         buffs_provided: vec![],
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     }
 }
 

--- a/crates/data/tests/issue_74_collei_c6.rs
+++ b/crates/data/tests/issue_74_collei_c6.rs
@@ -27,6 +27,7 @@ fn dummy_member(element: Element) -> TeamMember {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     }
 }
 

--- a/crates/data/tests/meta_team_edge_cases.rs
+++ b/crates/data/tests/meta_team_edge_cases.rs
@@ -61,6 +61,7 @@ fn edge_res_shred_stacking() {
         buffs_provided: vec![],
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     };
 
     let team = [dps, kazuha, zhongli];
@@ -377,6 +378,7 @@ fn edge_furina_fanfare_scaling() {
         buffs_provided: vec![],
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     };
 
     let team_no_stacks = [furina, dps.clone()];
@@ -745,6 +747,7 @@ fn edge_bennett_c6_pyro_dmg() {
         buffs_provided: vec![],
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     };
 
     let team = [bennett_c6, dps];

--- a/crates/data/tests/meta_team_edge_cases.rs
+++ b/crates/data/tests/meta_team_edge_cases.rs
@@ -62,6 +62,7 @@ fn edge_res_shred_stacking() {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     };
 
     let team = [dps, kazuha, zhongli];
@@ -379,6 +380,7 @@ fn edge_furina_fanfare_scaling() {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     };
 
     let team_no_stacks = [furina, dps.clone()];
@@ -748,6 +750,7 @@ fn edge_bennett_c6_pyro_dmg() {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     };
 
     let team = [bennett_c6, dps];

--- a/crates/data/tests/meta_team_verification.rs
+++ b/crates/data/tests/meta_team_verification.rs
@@ -1355,6 +1355,7 @@ fn cross_team_bennett_buff_consistency() {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     };
 
     let dps2 = TeamMember {
@@ -1373,6 +1374,7 @@ fn cross_team_bennett_buff_consistency() {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     };
 
     let team1 = [bennett.clone(), dps1];

--- a/crates/data/tests/meta_team_verification.rs
+++ b/crates/data/tests/meta_team_verification.rs
@@ -1354,6 +1354,7 @@ fn cross_team_bennett_buff_consistency() {
         buffs_provided: vec![],
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     };
 
     let dps2 = TeamMember {
@@ -1371,6 +1372,7 @@ fn cross_team_bennett_buff_consistency() {
         buffs_provided: vec![],
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     };
 
     let team1 = [bennett.clone(), dps1];

--- a/crates/data/tests/team_integration.rs
+++ b/crates/data/tests/team_integration.rs
@@ -33,6 +33,7 @@ fn test_bennett_kazuha_team_damage() {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     };
 
     let team = [bennett, dps];

--- a/crates/data/tests/team_integration.rs
+++ b/crates/data/tests/team_integration.rs
@@ -32,6 +32,7 @@ fn test_bennett_kazuha_team_damage() {
         buffs_provided: vec![],
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     };
 
     let team = [bennett, dps];

--- a/crates/good/tests/evaluate_talent_buffs_integration.rs
+++ b/crates/good/tests/evaluate_talent_buffs_integration.rs
@@ -74,6 +74,7 @@ fn test_pipeline_build_member_stats_to_resolve_team() {
         buffs_provided: buffs,
         is_moonsign: false,
         can_nightsoul: false,
+        moonsign_benediction: None,
     };
 
     let result = genshin_calc_core::resolve_team_stats(&[member], 0, &[]);

--- a/crates/good/tests/evaluate_talent_buffs_integration.rs
+++ b/crates/good/tests/evaluate_talent_buffs_integration.rs
@@ -75,6 +75,7 @@ fn test_pipeline_build_member_stats_to_resolve_team() {
         is_moonsign: false,
         can_nightsoul: false,
         moonsign_benediction: None,
+        moonsign_talent_enhancements: &[],
     };
 
     let result = genshin_calc_core::resolve_team_stats(&[member], 0, &[]);

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -741,6 +741,7 @@ mod tests {
             buffs_provided: vec![],
             is_moonsign: false,
             can_nightsoul: false,
+            moonsign_benediction: None,
         };
         let result = resolve_team_stats(&[dps], 0, &[]).unwrap();
         assert!(result.final_stats.atk > 0.0);

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -742,6 +742,7 @@ mod tests {
             is_moonsign: false,
             can_nightsoul: false,
             moonsign_benediction: None,
+            moonsign_talent_enhancements: &[],
         };
         let result = resolve_team_stats(&[dps], 0, &[]).unwrap();
         assert!(result.final_stats.atk > 0.0);

--- a/crates/wasm/ts/types.ts
+++ b/crates/wasm/ts/types.ts
@@ -166,6 +166,13 @@ export interface ResolvedBuff {
   target: BuffTarget;
 }
 
+export interface MoonsignBenedictionSpec {
+  enabled_reactions: Reaction[];
+  scaling_stat: ScalingStat | null;
+  rate: number;
+  max_bonus: number;
+}
+
 export interface TeamMember {
   element: Element;
   weapon_type: WeaponType;
@@ -173,6 +180,24 @@ export interface TeamMember {
   buffs_provided: ResolvedBuff[];
   is_moonsign: boolean;
   can_nightsoul: boolean;
+  moonsign_benediction?: MoonsignBenedictionSpec | null;
+}
+
+export type MoonsignLevel = "None" | "NascentGleam" | "AscendantGleam";
+
+/**
+ * Team-level Moonsign context, exposed via `resolve_team_stats` / `TeamResolveResult`.
+ * Use `base_dmg_bonus_by_reaction` to obtain the per-reaction Base DMG Bonus
+ * that must be passed to `LunarInput.base_dmg_bonus` / `DirectLunarInput.base_dmg_bonus`.
+ * Use `non_moonsign_lunar_bonus` as `reaction_bonus` for non-moonsign members at AscendantGleam.
+ */
+export interface MoonsignContext {
+  level: MoonsignLevel;
+  base_dmg_bonus_by_reaction: Array<[Reaction, number]>;
+  non_moonsign_lunar_bonus: number;
+  // talent_enhancements contains `&'static str` fields (Rust-only); serialized
+  // form is available but not deserializable.
+  talent_enhancements: unknown[];
 }
 
 // === GOOD Import Types ===
@@ -379,4 +404,20 @@ export interface WeaponData {
 export interface ArtifactSetData {
   id: string;
   name: string;
+}
+
+
+/**
+ * Return type of `resolve_team_stats`. Includes the team-level Moonsign context
+ * (Issue #142) so JS/TS consumers can obtain `base_dmg_bonus_by_reaction` to
+ * feed into `LunarInput.base_dmg_bonus` / `DirectLunarInput.base_dmg_bonus`.
+ */
+export interface TeamResolveResult {
+  base_stats: Stats;
+  applied_buffs: ResolvedBuff[];
+  resonances: string[];
+  final_stats: Stats;
+  damage_context: unknown;
+  enemy_debuffs: unknown;
+  moonsign_context: MoonsignContext;
 }


### PR DESCRIPTION
## Summary
- Remove duplicate Flins A1 "Symphony of Winter" from `talent_buffs/electro.rs::FLINS_BUFFS`. Canonical location is `moonsign_chars.rs::FLINS_TALENT_ENHANCEMENTS`, which is routed automatically by the moonsign enhancement pipeline introduced in #143.
- Without this, toggling the `talent_buffs` version after #143 landed would double-count the +20% (0.40 total).
- The `talent_buffs` version also used broad `TransformativeBonus`, which would over-apply to every transformative reaction (Swirl/Overloaded/Bloom/…). The remaining canonical entry uses `ReactionDmgBonus(LunarElectroCharged)` exactly.
- Add routing policy to `.claude/rules/conventions.md` so future moonsign effects land in exactly one place.

## Test plan
- [x] `crates/data/tests/issue_144_flins_a1_dedupe.rs`
  - `test_flins_a1_not_registered_in_talent_buffs` — asserts no Ascension(1) buff in `talent_buffs`
  - `test_flins_a1_still_routes_at_ascendant_gleam` — asserts exactly `+0.20` delivered via `MoonsignContext`/`DamageContext` at AscendantGleam
- [x] Updated `issue_106_113_electro_anemo.rs` expectations (7 → 6 Flins buffs)
- [x] `cargo test --workspace --all-targets` green
- [x] `cargo clippy -p genshin-calc-data --lib -- -D warnings` clean
- [x] `cargo fmt --check` clean

## Sequencing
Based on top of #146 (#143). Merge after #145 and #146 land.

## Related
- Closes #144