### PR TITLE
fix(data): dedupe Flins A1 + document moonsign routing policy (#144)

### DIFF
--- a/.claude/rules/conventions.md
+++ b/.claude/rules/conventions.md
@@ -21,6 +21,20 @@
 - チームエネルギー合計系武器（AKUOUMARU/WAVEBREAKERS_FIN/MOUUNS_MOON）はToggle使用（StatScalingは単一キャラのstat参照のみ）
 - `team_builder.rs`注意: `Both(auto, manual)`はauto_valをeval_manualのbase_valueとして渡す。Toggle→auto_val返却、Stacks→auto_val×n
 
+## Moonsign Effect Routing Policy (#144)
+月兆キャラの効果は2系統あるが、**1効果につき1箇所のみ**に登録すること。両方に書くと #143 の moonsign enhancement pipeline によって二重加算される。
+
+- **Moonsign level gated** (Nascent/Ascendant Gleam 条件付き) → `moonsign_chars.rs::*_TALENT_ENHANCEMENTS`
+  - 例: Flins A1 "Symphony of Winter" (Ascendant Gleam で +20%), Aino C6 (Nascent +15% / Ascendant +35%), Lauma A1 crit grants, Nefer A1 EM+100
+  - `resolve_team_stats` がチームレベル判定後に自動配線 (`StatBuff` → `applied_buffs`, `ReactionDmgBonus` → `damage_context.reaction_dmg_bonuses`)
+  - `GrantReactionCrit` のみ `apply_moonsign_enhancements` 経由で lunar pipeline に手動適用必要
+  - reaction 複数対象の場合は個別エントリに展開すること (`ReactionDmgBonus` が単一 reaction のみ受け付けるため)
+- **Level gate 無依存** (凸・天賦レベルのみ条件) → `talent_buffs/<element>.rs::TalentBuffDef`
+  - 例: Flins C6 self/team (C6 単独条件), Columbina C4/C6, Nefer C6 lunar bloom +15%
+  - reaction 単一ターゲティングには `BuffableStat::ReactionDmgBonus(reaction)` を使用 (`TransformativeBonus` は全変化反応に波及するため対象外)
+
+新規月兆効果追加時は上記 routing decision を PR description に明記すること。
+
 ## Critical Change Warning
 - `DamageInput`/`LunarInput`/`TeamMember`変更時は全構築箇所（テスト・docコメント・README・examples含む）を一括修正すること（コンパイル不能防止）
 - `TalentBuffDef.name`変更時は全`.activate()`呼び出し箇所をGrepで検索・一括更新すること（テスト内の`.activate("旧名")`が残ると実行時に無視される）

--- a/crates/data/src/talent_buffs/electro.rs
+++ b/crates/data/src/talent_buffs/electro.rs
@@ -90,28 +90,14 @@ static LISA_BUFFS: &[TalentBuffDef] = &[TalentBuffDef {
 }];
 
 // ===== Flins =====
-// A1 passive "Symphony of Winter": Lunar-Charged DMG +20% (self, Toggle)
+// A1 "Symphony of Winter" (Lunar-Charged DMG +20% at Ascendant Gleam): moved
+// to moonsign_chars.rs::FLINS_TALENT_ENHANCEMENTS (Issue #144) — it is a
+// Moonsign-level-gated effect, routed via the moonsign enhancement pipeline.
 // A4 passive "Whispering Flame": EM += total ATK × 0.08, capped at 160
 // C4 "Night on Bald Mountain": ATK +20%
 // C2: Opponents' Electro RES -25% during Ascendant Gleam Moonsign
 // C6: Flins's Lunar-Charged DMG +35%, Party Lunar-Charged DMG +10% during Moonsign
 static FLINS_BUFFS: &[TalentBuffDef] = &[
-    TalentBuffDef {
-        name: "Symphony of Winter",
-        description: desc!(
-            "A1: Lunar-Charged reactions triggered by Flins deal an additional 20% DMG"
-        ),
-        stat: BuffableStat::TransformativeBonus,
-        base_value: 0.20,
-        scales_with_talent: false,
-        talent_scaling: None,
-        scales_on: None,
-        target: BuffTarget::OnlySelf,
-        source: TalentBuffSource::AscensionPassive(1),
-        min_constellation: 0,
-        cap: None,
-        activation: Some(Activation::Manual(ManualCondition::Toggle)),
-    },
     TalentBuffDef {
         name: "Whispering Flame EM Bonus",
         description: desc!("A4: Flins gains EM equal to 8% of her total ATK (max 160)"),

--- a/crates/data/tests/issue_106_113_electro_anemo.rs
+++ b/crates/data/tests/issue_106_113_electro_anemo.rs
@@ -52,40 +52,35 @@ fn test_ororon_total_buff_count() {
     );
 }
 
-// ===== Issue #107: Flins A1 "Symphony of Winter" Lunar-Charged DMG +20% =====
+// ===== Issue #107 / #144: Flins A1 "Symphony of Winter" Lunar-Charged DMG +20% =====
+// Canonical location moved to moonsign_chars.rs::FLINS_TALENT_ENHANCEMENTS (Issue
+// #144). The talent_buffs/electro.rs duplicate was removed to avoid double-count
+// after the moonsign enhancement pipeline (Issue #143) started auto-applying
+// moonsign-level-gated effects.
 
-/// Flins A1 should grant Lunar-Charged DMG +20% (TransformativeBonus, OnlySelf, Toggle)
+/// Flins A1 must live in moonsign_chars.rs and NOT in talent_buffs/.
 #[test]
-fn test_flins_a1_symphony_of_winter_lunar_charged_dmg() {
+fn test_flins_a1_is_not_in_talent_buffs() {
     let buffs = find_talent_buffs("flins").expect("flins buffs not found");
     let a1_buff = buffs
         .iter()
-        .find(|b| b.source == TalentBuffSource::AscensionPassive(1))
-        .expect("Flins A1 buff not found");
-    assert_eq!(
-        a1_buff.stat,
-        BuffableStat::TransformativeBonus,
-        "Flins A1 should use TransformativeBonus for Lunar-Charged DMG"
-    );
+        .find(|b| b.source == TalentBuffSource::AscensionPassive(1));
     assert!(
-        (a1_buff.base_value - 0.20).abs() < EPS,
-        "Flins A1 should be +20%"
-    );
-    assert_eq!(a1_buff.target, BuffTarget::OnlySelf);
-    assert_eq!(
-        a1_buff.activation,
-        Some(Activation::Manual(ManualCondition::Toggle))
+        a1_buff.is_none(),
+        "Flins A1 is moonsign-level-gated and must live in \
+         moonsign_chars.rs::FLINS_TALENT_ENHANCEMENTS, not talent_buffs/"
     );
 }
 
-/// Flins should now have 7 buffs (A1 new, A4, C4 ATK, C4 A4 enhance, C2 res, C6 self, C6 team)
+/// Flins should have 6 talent_buffs entries after A1 was moved out:
+/// A4, C4 ATK, C4 A4 enhance, C2 res, C6 self, C6 team.
 #[test]
 fn test_flins_total_buff_count() {
     let buffs = find_talent_buffs("flins").expect("flins buffs not found");
     assert_eq!(
         buffs.len(),
-        7,
-        "Flins should have 7 buffs (A1 + existing 6)"
+        6,
+        "Flins should have 6 talent_buffs (A1 moved to moonsign_chars.rs)"
     );
 }
 

--- a/crates/data/tests/issue_144_flins_a1_dedupe.rs
+++ b/crates/data/tests/issue_144_flins_a1_dedupe.rs
@@ -1,0 +1,50 @@
+//! Issue #144: Flins A1 "Symphony of Winter" (+20% Lunar-Charged DMG) must not
+//! be double-counted. Canonical source is `moonsign_chars.rs::FLINS_TALENT_ENHANCEMENTS`
+//! (routed automatically by the moonsign pipeline once team reaches Ascendant
+//! Gleam); the duplicate in `talent_buffs/electro.rs` is removed.
+
+use genshin_calc_core::*;
+use genshin_calc_data::{TeamMemberBuilder, find_character, find_weapon, talent_buffs};
+
+const EPSILON: f64 = 1e-6;
+
+#[test]
+fn test_flins_a1_not_registered_in_talent_buffs() {
+    let buffs = talent_buffs::find_talent_buffs("flins").expect("Flins talent buffs");
+    assert!(
+        !buffs.iter().any(|b| b.name == "Symphony of Winter"),
+        "Flins A1 'Symphony of Winter' must not live in talent_buffs (duplicate \
+         with moonsign_chars.rs::FLINS_TALENT_ENHANCEMENTS)"
+    );
+}
+
+#[test]
+fn test_flins_a1_still_routes_at_ascendant_gleam() {
+    let flins_char = find_character("flins").expect("Flins character data");
+    let columbina_char = find_character("columbina").expect("Columbina character data");
+    let weapon = find_weapon("prototype_rancour")
+        .or_else(|| find_weapon("favonius_greatsword"))
+        .or_else(|| find_weapon("the_black_sword"))
+        .expect("a neutral fallback weapon");
+
+    let flins = TeamMemberBuilder::new(flins_char, weapon)
+        .build()
+        .expect("Flins TeamMember");
+    let columbina = TeamMemberBuilder::new(columbina_char, weapon)
+        .build()
+        .expect("Columbina TeamMember");
+
+    let result = resolve_team_stats(&[flins, columbina], 0, &[]).unwrap();
+    assert_eq!(result.moonsign_context.level, MoonsignLevel::AscendantGleam);
+
+    // LunarElectroCharged reaction bonus must include exactly +20% from A1
+    // (no double-count, no missing).
+    let bonus = result
+        .damage_context
+        .reaction_bonus_for(Reaction::LunarElectroCharged);
+    assert!(
+        (bonus - 0.20).abs() < EPSILON,
+        "expected exactly +20% LunarEC bonus, got {}",
+        bonus
+    );
+}


### PR DESCRIPTION
Supersedes #147 (closed after its base branch was deleted on #148 merge).

## Summary
- Remove duplicate Flins A1 "Symphony of Winter" from `talent_buffs/electro.rs`. Canonical location is `moonsign_chars.rs::FLINS_TALENT_ENHANCEMENTS`, routed by the moonsign enhancement pipeline (#148).
- Without this, toggling the `talent_buffs` version would double-count +20% → +40% now that the pipeline is live.
- The removed entry also used broad `TransformativeBonus`, which over-applied to every transformative reaction; the canonical entry uses `ReactionDmgBonus(LunarElectroCharged)` exactly.
- Document Moonsign routing policy in `.claude/rules/conventions.md` to prevent recurrence.

## Test plan
- [x] `crates/data/tests/issue_144_flins_a1_dedupe.rs` (2 tests)
- [x] Updated `issue_106_113_electro_anemo.rs` expectations (7 → 6 Flins buffs, A1 moved)
- [x] `cargo test --workspace --all-targets` green
- [x] `cargo test --doc` green
- [x] `cargo clippy` clean

## Related
- Closes #144